### PR TITLE
TermsDisplayViewのUIデザイン、Controllerを作成し画面遷移も実装した

### DIFF
--- a/DietApp.xcodeproj/project.pbxproj
+++ b/DietApp.xcodeproj/project.pbxproj
@@ -59,6 +59,9 @@
 		FA9E8C392D11AD5E00A05E55 /* TermsOfUseTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA9E8C372D11AD5E00A05E55 /* TermsOfUseTableViewCell.xib */; };
 		FA9E8C3C2D11AD8B00A05E55 /* PrivacyPolicyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA9E8C3B2D11AD8B00A05E55 /* PrivacyPolicyTableViewCell.xib */; };
 		FA9E8C3D2D11AD8B00A05E55 /* PrivacyPolicyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9E8C3A2D11AD8B00A05E55 /* PrivacyPolicyTableViewCell.swift */; };
+		FA9E8C402D14641C00A05E55 /* TermsDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9E8C3F2D14641C00A05E55 /* TermsDisplayView.swift */; };
+		FA9E8C422D14643E00A05E55 /* TermsDisplayView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA9E8C412D14643E00A05E55 /* TermsDisplayView.xib */; };
+		FA9E8C442D14649300A05E55 /* TermsDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9E8C432D14649300A05E55 /* TermsDisplayViewController.swift */; };
 		FA9F9CE42CF449030013886A /* UIColor + AppThemeColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9F9CE32CF449030013886A /* UIColor + AppThemeColor.swift */; };
 		FA9F9CEB2CF5A6CC0013886A /* ChartAxisBase + setKGFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9F9CEA2CF5A6CC0013886A /* ChartAxisBase + setKGFormatter.swift */; };
 		FA9F9CED2CF5A8540013886A /* TransitionDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9F9CEC2CF5A8540013886A /* TransitionDirection.swift */; };
@@ -179,6 +182,9 @@
 		FA9E8C372D11AD5E00A05E55 /* TermsOfUseTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TermsOfUseTableViewCell.xib; sourceTree = "<group>"; };
 		FA9E8C3A2D11AD8B00A05E55 /* PrivacyPolicyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyTableViewCell.swift; sourceTree = "<group>"; };
 		FA9E8C3B2D11AD8B00A05E55 /* PrivacyPolicyTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrivacyPolicyTableViewCell.xib; sourceTree = "<group>"; };
+		FA9E8C3F2D14641C00A05E55 /* TermsDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsDisplayView.swift; sourceTree = "<group>"; };
+		FA9E8C412D14643E00A05E55 /* TermsDisplayView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TermsDisplayView.xib; sourceTree = "<group>"; };
+		FA9E8C432D14649300A05E55 /* TermsDisplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsDisplayViewController.swift; sourceTree = "<group>"; };
 		FA9F9CE32CF449030013886A /* UIColor + AppThemeColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + AppThemeColor.swift"; sourceTree = "<group>"; };
 		FA9F9CEA2CF5A6CC0013886A /* ChartAxisBase + setKGFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChartAxisBase + setKGFormatter.swift"; sourceTree = "<group>"; };
 		FA9F9CEC2CF5A8540013886A /* TransitionDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionDirection.swift; sourceTree = "<group>"; };
@@ -351,8 +357,7 @@
 			children = (
 				FA22110F2CFF59C2005C622D /* Notification */,
 				FAC9EF322D0C39FF00DE1E64 /* DeleteData */,
-				FA9E8C352D11ACBE00A05E55 /* TermsofUse */,
-				FA9E8C342D11AC8F00A05E55 /* PrivacyPolicy */,
+				FA9E8C3E2D1462F400A05E55 /* Terms */,
 				FA22110E2CFF1A23005C622D /* BaseView */,
 			);
 			path = Cell;
@@ -475,6 +480,17 @@
 			path = TermsofUse;
 			sourceTree = "<group>";
 		};
+		FA9E8C3E2D1462F400A05E55 /* Terms */ = {
+			isa = PBXGroup;
+			children = (
+				FA9E8C352D11ACBE00A05E55 /* TermsofUse */,
+				FA9E8C342D11AC8F00A05E55 /* PrivacyPolicy */,
+				FA9E8C3F2D14641C00A05E55 /* TermsDisplayView.swift */,
+				FA9E8C412D14643E00A05E55 /* TermsDisplayView.xib */,
+			);
+			path = Terms;
+			sourceTree = "<group>";
+		};
 		FA9F9CE22CF436B50013886A /* Utilitis */ = {
 			isa = PBXGroup;
 			children = (
@@ -531,6 +547,7 @@
 				FAC9EF0F2D0C0B5C00DE1E64 /* SettingsViewController.swift */,
 				FAC9EF0D2D0C0B5C00DE1E64 /* NotificationSettingViewController.swift */,
 				FAC9EF462D0C5A6F00DE1E64 /* DataDeletionExecutionViewController.swift */,
+				FA9E8C432D14649300A05E55 /* TermsDisplayViewController.swift */,
 			);
 			path = SettingsPage;
 			sourceTree = "<group>";
@@ -766,6 +783,7 @@
 				FA1187A32A22F652004577F8 /* AdTableViewCell.xib in Resources */,
 				FA32F4C52A32BFCF0058FD32 /* NotificationTableViewCell.xib in Resources */,
 				FA68AF282A135F6F00B69D4A /* Main.storyboard in Resources */,
+				FA9E8C422D14643E00A05E55 /* TermsDisplayView.xib in Resources */,
 				FA9E8C3C2D11AD8B00A05E55 /* PrivacyPolicyTableViewCell.xib in Resources */,
 				FAC9EF352D0C3A7900DE1E64 /* DeleteDataTableViewCell.xib in Resources */,
 				FA2211132CFF5B8A005C622D /* NotificationSettingView.xib in Resources */,
@@ -907,6 +925,7 @@
 				FA1187A22A22F652004577F8 /* AdTableViewCell.swift in Sources */,
 				FAC9EF432D0C562E00DE1E64 /* DataDeletionExecutionView.swift in Sources */,
 				FA2211112CFF5AF4005C622D /* NotificationSettingView.swift in Sources */,
+				FA9E8C442D14649300A05E55 /* TermsDisplayViewController.swift in Sources */,
 				FA97A9752D014EF800BC85A8 /* NotificationRegisterTableViewCell.swift in Sources */,
 				FAC9EF2D2D0C11C200DE1E64 /* LocalNotificationManager.swift in Sources */,
 				FAC0A8A82D06D3010074D818 /* Date + ConvertDateToNotificationTimeString.swift in Sources */,
@@ -944,6 +963,7 @@
 				FA32F4B82A32BD130058FD32 /* SettingsView.swift in Sources */,
 				FA22110B2CFF1525005C622D /* ShadowLayerView.swift in Sources */,
 				FA9F9CED2CF5A8540013886A /* TransitionDirection.swift in Sources */,
+				FA9E8C402D14641C00A05E55 /* TermsDisplayView.swift in Sources */,
 				FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */,
 				FAC9EF362D0C3A7900DE1E64 /* DeleteDataTableViewCell.swift in Sources */,
 				FA24A8732CA66F110082AF19 /* OrientationManager.swift in Sources */,

--- a/DietApp/Controller/SettingsPage/SettingsViewController.swift
+++ b/DietApp/Controller/SettingsPage/SettingsViewController.swift
@@ -185,11 +185,13 @@ extension SettingsViewController: UITableViewDelegate,UITableViewDataSource {
     case .termsOfUseTableViewCell:
       let cell = preCastCell as! TermsOfUseTableViewCell
       cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      cell.delegate = self
       return cell
       
     case .privacyPolicyTableViewCell:
       let cell = preCastCell as! PrivacyPolicyTableViewCell
       cell.selectionStyle = UITableViewCell.SelectionStyle.none
+      cell.delegate = self
       return cell
     }
   }
@@ -275,5 +277,26 @@ extension SettingsViewController: DeleteDataTableViewCellDelegate {
     let storyBoard = UIStoryboard(name: "Main", bundle: nil)
     guard let notificationSettingViewController = storyBoard.instantiateViewController(withIdentifier: "DataDeletionExecution") as? DataDeletionExecutionViewController else { return }
     self.navigationController?.pushViewController(notificationSettingViewController, animated: true)
+  }
+}
+//利用規約セルとプライバシーポリシーセルのデリゲート
+extension SettingsViewController: TermsOfUseTableViewCellDelegate, PrivacyPolicyTableViewCellDelegate   {
+  
+  func TermsOfUseTransitionButtonAction() {
+    let termsDisplayViewController = initTermsDisplayViewController()
+    termsDisplayViewController.termsType = .termsOfUse
+    navigationController?.pushViewController(termsDisplayViewController, animated: true)
+  }
+  
+  func privacyPolicyTransitionButtonAction() {
+    let termsDisplayViewController = initTermsDisplayViewController()
+    termsDisplayViewController.termsType = .privacyPolicy
+    navigationController?.pushViewController(termsDisplayViewController, animated: true)
+  }
+  
+  func initTermsDisplayViewController() -> TermsDisplayViewController {
+    let storyBoard = UIStoryboard(name: "Main", bundle: nil)
+    let termsDisplayViewController = storyBoard.instantiateViewController(withIdentifier: "TermsDisplay") as! TermsDisplayViewController
+    return termsDisplayViewController
   }
 }

--- a/DietApp/Controller/SettingsPage/TermsDisplayViewController.swift
+++ b/DietApp/Controller/SettingsPage/TermsDisplayViewController.swift
@@ -1,0 +1,58 @@
+//
+//  TermsDisplayViewController.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2024/12/19.
+//
+
+import UIKit
+
+class TermsDisplayViewController: UIViewController {
+  
+  let termsDisplayView =  TermsDisplayView()
+  
+  var termsType: TermsType!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+      
+      loadContent()
+        // Do any additional setup after loading the view.
+    }
+  
+  override func loadView() {
+    super.loadView()
+    view = termsDisplayView
+  }
+
+  enum TermsType {
+    case termsOfUse
+    case privacyPolicy
+    
+    var url: URL? {
+      switch self {
+      case .termsOfUse:
+        return URL(string: "https://night-beryl-de2.notion.site/DietApp-1619e6db1ebc801297fdfef8e61cc911?pvs=4")
+      case .privacyPolicy:
+        return URL(string: "https://night-beryl-de2.notion.site/DietApp-1619e6db1ebc801097eed65897bb162f?pvs=4")
+      }
+    }
+  }
+  
+  private func loadContent() {
+    if let url = termsType.url {
+      let request = URLRequest(url: url)
+      termsDisplayView.webView.load(request)
+    }
+  }
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/DietApp/View/Base.lproj/Main.storyboard
+++ b/DietApp/View/Base.lproj/Main.storyboard
@@ -91,6 +91,21 @@
             </objects>
             <point key="canvasLocation" x="2380" y="2106"/>
         </scene>
+        <!--Terms Display View Controller-->
+        <scene sceneID="22a-K2-gbQ">
+            <objects>
+                <viewController storyboardIdentifier="TermsDisplay" id="53H-BJ-shI" customClass="TermsDisplayViewController" customModule="DietApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="0mN-jh-KAF">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="RGs-bE-WHd"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MW2-5b-v0w" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2380" y="2826"/>
+        </scene>
         <!--Top View Controller-->
         <scene sceneID="42X-Xj-WhJ">
             <objects>

--- a/DietApp/View/SettingsPage/Cell/Terms/PrivacyPolicy/PrivacyPolicyTableViewCell.swift
+++ b/DietApp/View/SettingsPage/Cell/Terms/PrivacyPolicy/PrivacyPolicyTableViewCell.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol PrivacyPolicyTableViewCellDelegate {
+  func privacyPolicyTransitionButtonAction()
+}
+
 class PrivacyPolicyTableViewCell: UITableViewCell {
 
   @IBOutlet weak var shadowLayerView: UIView!
@@ -17,6 +21,7 @@ class PrivacyPolicyTableViewCell: UITableViewCell {
       transitionButton.tintColor = .YellowishRed
     }
   }
+  var delegate: PrivacyPolicyTableViewCellDelegate?
   
   override func awakeFromNib() {
         super.awakeFromNib()
@@ -29,5 +34,8 @@ class PrivacyPolicyTableViewCell: UITableViewCell {
 
         // Configure the view for the selected state
     }
-    
+  @IBAction func transitionButtonAction(_ sender: UIButton) {
+    delegate?.privacyPolicyTransitionButtonAction()
+  }
+  
 }

--- a/DietApp/View/SettingsPage/Cell/Terms/PrivacyPolicy/PrivacyPolicyTableViewCell.xib
+++ b/DietApp/View/SettingsPage/Cell/Terms/PrivacyPolicy/PrivacyPolicyTableViewCell.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -38,6 +37,9 @@
                                 <buttonConfiguration key="configuration" style="plain" image="chevron.forward" catalog="system">
                                     <color key="baseForegroundColor" name="YellowishRed"/>
                                 </buttonConfiguration>
+                                <connections>
+                                    <action selector="transitionButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="o0O-1P-1AC"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.swift
+++ b/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.swift
@@ -1,0 +1,45 @@
+//
+//  TermsDisplayView.swift
+//  DietApp
+//
+//  Created by 川島真之 on 2024/12/19.
+//
+
+import UIKit
+import WebKit
+
+class TermsDisplayView: UIView {
+  
+
+  @IBOutlet weak var webView: WKWebView!
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    nibInit()
+  }
+  
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+    nibInit()
+  }
+  
+  func nibInit() {
+    //xibファイルのインスタンス作成
+    let nib = UINib(nibName: "TermsDisplayView", bundle: nil)
+    guard let view = nib.instantiate(withOwner: self, options: nil).first as? UIView else { return }
+    //viewのサイズを画面のサイズと一緒にする
+    view.frame = self.bounds
+    //サイズの自動調整
+    view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+    self.addSubview(view)
+  }
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.xib
+++ b/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.xib
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TermsDisplayView" customModule="DietApp" customModuleProvider="target">
+            <connections>
+                <outlet property="webView" destination="fVl-jq-1Ju" id="73e-2m-q9d"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fVl-jq-1Ju">
+                    <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="fVl-jq-1Ju" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="FOJ-sn-cHK"/>
+                <constraint firstItem="fVl-jq-1Ju" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="PH1-MC-xC6"/>
+                <constraint firstItem="fVl-jq-1Ju" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="UoH-tQ-c4Q"/>
+                <constraint firstItem="fVl-jq-1Ju" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="xDX-iE-lfo"/>
+            </constraints>
+            <point key="canvasLocation" x="41.984732824427482" y="-1.4084507042253522"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/DietApp/View/SettingsPage/Cell/Terms/TermsofUse/TermsOfUseTableViewCell.swift
+++ b/DietApp/View/SettingsPage/Cell/Terms/TermsofUse/TermsOfUseTableViewCell.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol TermsOfUseTableViewCellDelegate {
+  func TermsOfUseTransitionButtonAction()
+}
+
 class TermsOfUseTableViewCell: UITableViewCell {
 
   @IBOutlet weak var shadowLayerView: UIView!
@@ -17,6 +21,7 @@ class TermsOfUseTableViewCell: UITableViewCell {
       transitionButton.tintColor = .YellowishRed
     }
   }
+  var delegate: TermsOfUseTableViewCellDelegate?
   
   override func awakeFromNib() {
         super.awakeFromNib()
@@ -29,5 +34,9 @@ class TermsOfUseTableViewCell: UITableViewCell {
 
         // Configure the view for the selected state
     }
-    
+  
+  @IBAction func transitionButtonAction(_ sender: UIButton) {
+    delegate?.TermsOfUseTransitionButtonAction()
+  }
+  
 }

--- a/DietApp/View/SettingsPage/Cell/Terms/TermsofUse/TermsOfUseTableViewCell.xib
+++ b/DietApp/View/SettingsPage/Cell/Terms/TermsofUse/TermsOfUseTableViewCell.xib
@@ -31,6 +31,9 @@
                                 <buttonConfiguration key="configuration" style="plain" image="chevron.forward" catalog="system">
                                     <color key="baseForegroundColor" name="YellowishRed"/>
                                 </buttonConfiguration>
+                                <connections>
+                                    <action selector="transitionButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Euw-bV-Roy"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="利用規約" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VlT-67-jap">
                                 <rect key="frame" x="8" y="8" width="64" height="21"/>


### PR DESCRIPTION
## issue
close #156 

## やったこと
- TermsDisplayViewのおおまかなUIデザイン
- TermsDisplayViewControllerの作成
- 画面遷移の実装
- 遷移時にNotionページを表示するようにした。
- Notionでのページ作成
## TermsDisplayViewのUIデザイン
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-12-20 at 13 12 29](https://github.com/user-attachments/assets/918ee8a4-2146-43b8-94b2-f4b7f1e199c0)

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-12-20 at 13 12 59](https://github.com/user-attachments/assets/22eaa138-260c-4930-abad-74ad96ed1129)


## やっていないこと
- TermsDisplayViewの細かなUIデザイン
- NotionのUIデザイン
- プライバシーポリシー、利用規約の文章作成
- 遷移時のインディケーターの実装
## その他
