### PR TITLE
規約表示画面遷移時のワーニングの確認をした

### DIFF
--- a/DietApp/Controller/SettingsPage/TermsDisplayViewController.swift
+++ b/DietApp/Controller/SettingsPage/TermsDisplayViewController.swift
@@ -6,25 +6,31 @@
 //
 
 import UIKit
+import WebKit
 
 class TermsDisplayViewController: UIViewController {
   
   let termsDisplayView =  TermsDisplayView()
   
   var termsType: TermsType!
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-      
-      loadContent()
-        // Do any additional setup after loading the view.
-    }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    loadContent()
+    // Do any additional setup after loading the view.
+  }
   
   override func loadView() {
     super.loadView()
     view = termsDisplayView
   }
-
+  
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    cleanupWebView()
+  }
+  
   enum TermsType {
     case termsOfUse
     case privacyPolicy
@@ -45,14 +51,31 @@ class TermsDisplayViewController: UIViewController {
       termsDisplayView.webView.load(request)
     }
   }
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+  
+  
+  //WebViewが使用するリソースの解放処理
+  //ログの警告を非表示にするための処理
+  private func cleanupWebView() {
+    
+    let webView = termsDisplayView.webView!
+    // 読み込みを停止
+    webView.stopLoading()
+    
+    // キャッシュをクリア
+    if #available(iOS 9.0, *) {
+      WKWebsiteDataStore.default().removeData(
+        ofTypes: [WKWebsiteDataTypeMemoryCache, WKWebsiteDataTypeDiskCache],
+        modifiedSince: Date(timeIntervalSince1970: 0),
+        completionHandler: { }
+      )
     }
-    */
-
+    
+    // 空のページを読み込んでリソースを解放
+    webView.loadHTMLString("", baseURL: nil)
+  }
+  
+  deinit {
+    termsDisplayView.webView.navigationDelegate = nil
+    termsDisplayView.webView.uiDelegate = nil
+  }
 }


### PR DESCRIPTION
## issue
close #158 
## やったこと

- 規約表示画面遷移時のワーニングの確認
- WKWebViewが使用していたプロセスの終了時のワーニングに対処した

## WKWebViewが使用していたプロセスの終了時のワーニングへの対処
### Failed to terminate process: Error Domain=com.apple.extensionKit.errorDomain Code=18
おそらくプロセスを終了しようとしたときに、既にプロセスが終了していためエラーが発生している。
これは無視しても問題なさそうだが、他のワーニングを解消するかどうかの判断をしたかったためとりあえずこのワーニングだけ対処してみることにした。
対処方法はWebViewが使用するリソースの解放処理をviewWillDisappear内で実行することにした。
## やっていないこと
- 上記以外のワーニングへの対処
- AutoLayout関係のワーニングへの対処
## なぜやらなかったか
### 上記以外のワーニングへの対処
確認できた警告は全てiOSやフレームワークの内部的な警告であり、アプリの動作には影響せず無視して問題ないものだった。
解消することもできるがコード量が増えてしまうので放置することにした。
### AutoLayout関係のワーニングへの対処
AutoLayout関係のワーニングが発生しなくなったため。
前日では間違いなく発生していたが今回の作業中には発生しなかった。発生条件も不明なため発生次第対処することにして今回は様子見をすることにした。
## その他
