### PR TITLE
規約表示画面のUIデザインの微調整と遷移時のインジケーターを実装

### DIFF
--- a/DietApp/Controller/SettingsPage/TermsDisplayViewController.swift
+++ b/DietApp/Controller/SettingsPage/TermsDisplayViewController.swift
@@ -11,11 +11,26 @@ import WebKit
 class TermsDisplayViewController: UIViewController {
   
   let termsDisplayView =  TermsDisplayView()
-  
   var termsType: TermsType!
+  //インジケーター
+  private let indicator: UIActivityIndicatorView = {
+    let indicator = UIActivityIndicatorView(style: .large) // largeスタイルに変更
+    indicator.hidesWhenStopped = true
+    indicator.color = .gray // 必要に応じて色を調整
+    return indicator
+  }()
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    
+    termsDisplayView.webView.navigationDelegate = self
+    
+    view.addSubview(indicator)
+    indicator.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      indicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      indicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+    ])
     
     loadContent()
     // Do any additional setup after loading the view.
@@ -77,5 +92,23 @@ class TermsDisplayViewController: UIViewController {
   deinit {
     termsDisplayView.webView.navigationDelegate = nil
     termsDisplayView.webView.uiDelegate = nil
+  }
+}
+
+//WKWebViewでのWebコンテンツのナビゲーション（読み込みやリダイレクトなど）を制御・監視するデリゲートメソッド
+extension TermsDisplayViewController: WKNavigationDelegate {
+  
+  func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    indicator.startAnimating()
+  }
+  
+  // WebViewの読み込み完了時
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    indicator.stopAnimating()
+  }
+  
+  // WebViewの読み込み失敗時
+  func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    indicator.stopAnimating()
   }
 }

--- a/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.swift
+++ b/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.swift
@@ -11,7 +11,11 @@ import WebKit
 class TermsDisplayView: UIView {
   
 
-  @IBOutlet weak var webView: WKWebView!
+  @IBOutlet weak var webView: WKWebView! {
+    didSet {
+      webView.backgroundColor = .white
+    }
+  }
   
   override init(frame: CGRect) {
     super.init(frame: frame)

--- a/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.xib
+++ b/DietApp/View/SettingsPage/Cell/Terms/TermsDisplayView.xib
@@ -21,7 +21,7 @@
             <subviews>
                 <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fVl-jq-1Ju">
                     <rect key="frame" x="0.0" y="59" width="393" height="759"/>
-                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <wkWebViewConfiguration key="configuration">
                         <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                         <wkPreferences key="preferences"/>


### PR DESCRIPTION
## issue
close #160
## やったこと
- webViewの背景色を.whiteに変更した。
→ページが読み込まれるまで白い画面を表示されるようになった。

- 遷移時のインジケーターを実装

## やっていないこと
## その他
