### PR TITLE
バグの修正と通知セルの表記を変更した

### DIFF
--- a/DietApp/Model/Logic/DataDeleteManager.swift
+++ b/DietApp/Model/Logic/DataDeleteManager.swift
@@ -67,10 +67,22 @@ class DataDeleteManager {
     return true
   }
   
+  private func removeNotificationRequests() {
+    let center = UNUserNotificationCenter.current()
+
+    center.getPendingNotificationRequests { requests in
+      if !requests.isEmpty {
+        center.removeAllPendingNotificationRequests()
+      } else {
+        return
+      }
+    }
+  }
+  
   func deleteAllData() -> Bool {
     let DeleteRealmObjectResult = deleteRealmObject()
+    removeNotificationRequests()
     let clearDocumentDirectoryResult = clearDocumentDirectroy()
-    
     if DeleteRealmObjectResult && clearDocumentDirectoryResult {
       return true
     }

--- a/DietApp/Model/Logic/LocalNotificationManager.swift
+++ b/DietApp/Model/Logic/LocalNotificationManager.swift
@@ -27,8 +27,7 @@ class LocalNotificationManager {
     return settings.notification!
   }
   
-  /// 通知の許可を要求
-  /// - Parameter completion: 許可状態を返すクロージャ
+//ユーザーに通知の許可を確認するメソッド
   func requestAuthorization(completion: @escaping (Bool) -> Void) {
     UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge]) { granted, error in
       //ユーザーからの通知許可の返答を待つ
@@ -40,8 +39,14 @@ class LocalNotificationManager {
   //通知をスケジュールするメソッド
   //このモデルを使用するオブジェクトで呼ばれるメソッド
   func setScheduleNotification() {
+    //通知リクエストがあれば削除する
+    let center = UNUserNotificationCenter.current()
+    center.getPendingNotificationRequests { requests in
+      if !requests.isEmpty {
+        center.removeAllPendingNotificationRequests()
+      }
+    }
     
-    //既存の通知を消去
     let isEnabled = currentSettings.isNotificationEnabled
     //通知がオンなら通知をスケジュール
     if isEnabled {

--- a/DietApp/View/SettingsPage/Cell/Notification/NotificationTableViewCell.xib
+++ b/DietApp/View/SettingsPage/Cell/Notification/NotificationTableViewCell.xib
@@ -26,8 +26,8 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="syX-pv-JIu" customClass="MainBackgroundView" customModule="DietApp" customModuleProvider="target">
                         <rect key="frame" x="12" y="6" width="295" height="48"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="通知" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9yc-ps-Jhh">
-                                <rect key="frame" x="8" y="8" width="32" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="デイリー通知" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9yc-ps-Jhh">
+                                <rect key="frame" x="8" y="8" width="96" height="21"/>
                                 <fontDescription key="fontDescription" name="Thonburi-Light" family="Thonburi" pointSize="16"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>

--- a/DietAppTests/ModelTests/DataDeleteManagerTest.swift
+++ b/DietAppTests/ModelTests/DataDeleteManagerTest.swift
@@ -119,6 +119,33 @@ final class DataDeleteManagerTests: XCTestCase {
     }
     
   }
+  //通知リクエストが削除できているかのテスト
+  func testDeleteAllData_removeNotificationRequests() {
+    
+    let center = UNUserNotificationCenter.current()
+    //テスト用リクエストを設定
+    let content = UNMutableNotificationContent()
+    content.title = "テスト通知"
+    content.body = "これはテスト用の通知です"
+    content.sound = .default
+    
+    let component = DateComponents(hour: 12, minute: 0)
+    let trigger = UNCalendarNotificationTrigger(dateMatching: component, repeats: false)
+    let request = UNNotificationRequest(identifier: "alerm_id", content: content, trigger: trigger)
+    center.add(request) { error in
+      if let error {
+        print(error.localizedDescription)
+      }
+    }
+    
+    let deleteAllDataResult = sut.deleteAllData()
+    XCTAssertTrue(deleteAllDataResult)
+
+    center.getPendingNotificationRequests { requests in
+      let count = requests.count
+      XCTAssertTrue(count == 0)
+    }
+  }
   //RealmObjectが存在しない場合のテスト
   func testDeleteAllData_EmptyRealmObjectSuccess() {
     //全てのRealmObjectを事前に削除


### PR DESCRIPTION
## issue
close #162 
## やったこと

- 全データ削除後に通知が送信されてしまうバグを修正
- 設定画面の通知セルのラベルを「通知」から「デイリー通知」に変更した。

## 変更後の通知セル外観
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-12-22 at 21 28 34](https://github.com/user-attachments/assets/b23c2209-48eb-44c9-993d-40c4f8132056)

## やっていないこと

## その他
