### PR TITLE
写真読み込み失敗時のコメントラベル変更処理を実装

### DIFF
--- a/DietApp/Controller/TopPage/TopViewController.swift
+++ b/DietApp/Controller/TopPage/TopViewController.swift
@@ -219,6 +219,9 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       cell.selectionStyle = UITableViewCell.SelectionStyle.none
       //写真セルのデリゲート
       cell.delegate = self
+      //テキストカラーをダークグレイに再設定
+    //写真読み込み時にテキストカラーが.redに変更されるため
+      cell.commentLabel.textColor = .darkGray
             
       let dateDataRealmSearcher = DateDataRealmSearcher()
       let results = dateDataRealmSearcher.searchForDateDataInRealm(currentDate: topDateManager.date)
@@ -232,8 +235,10 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
           let imageOrientation = UIImage.Orientation(rawValue: results.first!.imageOrientationRawValue)
           let orientedPhotoImage = UIImage(cgImage: cgImage!, scale: 1.0, orientation: imageOrientation!)
           cell.photoImageView.image = orientedPhotoImage
-        } else {
+        } else { //画像ファイルの読み込みに失敗した時の処理
           cell.photoImageView.image = nil
+          cell.commentLabel.text = "読み込みエラー。写真の再セットをお願いします。"
+          cell.commentLabel.textColor = .red
         }
       } else {
         cell.photoImageView.image = nil

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -96,6 +96,9 @@ class PhotoTableViewCell: UITableViewCell {
   override func awakeFromNib() {
     super.awakeFromNib()
     
+    commentLabel.adjustsFontSizeToFitWidth = true
+    commentLabel.minimumScaleFactor = 0.5
+    
     photoImageView.backgroundColor = UIColor.OysterWhite
     //photoImageViewのimageを監視する
     //imageの値が変わるたびにnilが代入されたか否かで分岐して処理を行う


### PR DESCRIPTION
## issue
clsoe #185 
## やったこと
- ドキュメントパスから写真を読み込む処理が失敗したときにコメントラベルの表示内容を変更するするようにした。

## 読み込み失敗時のコメントラベル
![Simulator Screenshot - iPhone SE (3rd generation) - 2025-01-12 at 18 25 41](https://github.com/user-attachments/assets/0486f132-b279-491f-a1eb-2674da3a038d)

## やっていないこと
- 読み込み失敗時のViewの作成
当初は専用のViewを表示しようと思っていたが、コメントラベルの表示を変えるだけで済むことに気がついたのでそちらの手法を採用することにした。
## その他
