### PR TITLE
ダークモードを非対応にした

### DIFF
--- a/DietApp/Info.plist
+++ b/DietApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>NSUserNotificationsUsageDescription</key>
 	<string>記録時間の通知のため、許可が必要です</string>
 	<key>CFBundleIdentifier</key>

--- a/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
+++ b/DietApp/View/TopPage/Cell/PhotoTableViewCell.swift
@@ -106,7 +106,6 @@ class PhotoTableViewCell: UITableViewCell {
    //各種ボタンの初期設定
     let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 40)
     let image = insertButton.image(for: .normal)?.withConfiguration(symbolConfiguration)
-    insertButton.tintColor = UIColor.CornflowerBlue
     insertButton.setImage(image, for: .normal)
     insertButton.imageView?.contentMode = .scaleAspectFit
 


### PR DESCRIPTION
## issue
close #183 
## やったこと
- ダークモードを非対応にした。
- トップ画面の写真セルのボタンカラーをデフォルトカラーにした。
## やっていないこと
- systemColorの廃止
ダークモードとライトモードでアプリの外観を変えたくなかったのでsystemColorを廃止しようと思っていたが、そもそもダークモードに非対応にすれば両モードで外観が変わらなくなることに気がついたため。
## その他
