### PR TITLE
通知設定がオフの時でもローカル通知が送信されてしまう問題を修正した

### DIFF
--- a/DietApp/Controller/SettingsPage/SettingsViewController.swift
+++ b/DietApp/Controller/SettingsPage/SettingsViewController.swift
@@ -307,6 +307,12 @@ extension SettingsViewController: NotificationTableViewCellDelegate {
       settings.update { settings in
         settings.notification?.isNotificationEnabled = false
       }
+      //通知スケジュールの削除
+      let center = UNUserNotificationCenter.current()
+      center.getPendingNotificationRequests { requests in
+        center.removeAllPendingNotificationRequests()
+        center.removeAllDeliveredNotifications()
+      }
       //statuLabelの編集
       cell.statusLabel.text = "オフ"
       cell.statusLabel.textColor = .lightGray


### PR DESCRIPTION
## issue
close #200 
## やったこと
- 通知ボタンをオフにしたときに、現在設定されている通知スケジュールを削除するようにした。
## やっていないこと

## その他
