### PR TITLE
体重の削除バグを修正

### DIFF
--- a/Zidosuta/Controller/TopPage/TopViewController.swift
+++ b/Zidosuta/Controller/TopPage/TopViewController.swift
@@ -189,7 +189,8 @@ extension TopViewController: UITableViewDelegate,UITableViewDataSource {
       let dateDataRealmSearcher = DateDataRealmSearcher()
       let results = dateDataRealmSearcher.searchForDateDataInRealm(currentDate: topDateManager.date)
       
-      if results.isEmpty {
+      //検索結果が0件か、該当するデータの体重が0の場合は""をセットする
+      if results.isEmpty || results.first!.weight == 0 {
         cell.weightTextField.text = ""
       } else {
         let weightString = String(results.first!.weight)


### PR DESCRIPTION
## issue
close #216 
## やったこと
- トップ画面の体重セルの設定時に、該当日付のRealmデータの体重が０だった場合は""が体重テキストフィールドにセットされれるようにした。
## やっていないこと

## その他
