### PR TITLE
OKボタン周りの余白の微調整完了

### DIFF
--- a/Zidosuta/View/OnboardingView/PhotoTipsView.swift
+++ b/Zidosuta/View/OnboardingView/PhotoTipsView.swift
@@ -17,7 +17,7 @@ struct PhotoTipsView: View {
       ZStack {
         Color("YellowishRed")
           .ignoresSafeArea()
-        ZStack { //このZStack - レスポンシブマージン対応
+        ZStack {
           Color("OysterWhite")
           GeometryReader { geometry in
             
@@ -26,7 +26,7 @@ struct PhotoTipsView: View {
                 .font(.custom("Thonburi-Bold", size: geometry.size.width * 0.08, relativeTo: .body))
                 .foregroundStyle(.black)
                 .minimumScaleFactor(0.5)
-                .padding(.top, 60)
+                .padding(.top, 50)
               
               VStack {
                 Text(createAttributedString())
@@ -50,7 +50,7 @@ struct PhotoTipsView: View {
                   Image(systemName: "circle")
                     .foregroundStyle(.blue)
                     .font(.system(size: 40))
-                    .padding(.top, 15)
+                    .padding(.top, 8)
                 }
                 .padding(.leading, 5)
                 .padding(.trailing, 5)
@@ -65,7 +65,7 @@ struct PhotoTipsView: View {
                   Image(systemName: "triangle")
                     .foregroundStyle(.red)
                     .font(.system(size: 40))
-                    .padding(.top, 15)
+                    .padding(.top, 8)
                 }
                 .padding(.trailing, 5)
               }
@@ -105,7 +105,7 @@ struct PhotoTipsView: View {
                   .padding(.trailing, 20)
                 
               }
-              .padding(.bottom, 35)
+              .padding(.bottom, 30)
               .padding(.top, 10)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -122,12 +122,12 @@ struct PhotoTipsView: View {
   
   
   // MARK: - Method
-  
+  //外側のYellowishRedの領域の高さの設定
   private func calculateVerticalMargin(for screenSize: CGSize) -> CGFloat {
     
     let screenHeight = screenSize.height
   
-    let baseRatio: CGFloat = 0.047
+    let baseRatio: CGFloat = 0.050
     
     //許容される最小、最大の余白サイズ
     let minMargin: CGFloat = 10


### PR DESCRIPTION
## issue
close #254 
## やったこと
- 各Viewの余白の微調整

## UI
iPhone16 ProMax
<img width="305" alt="スクリーンショット 2025-06-03 20 04 15" src="https://github.com/user-attachments/assets/f87a5e98-2276-45b2-9958-bc9beea3f5ba" />

iPhoneSE
<img width="277" alt="スクリーンショット 2025-06-03 20 05 27" src="https://github.com/user-attachments/assets/fa9e257c-f58b-43e0-bcfc-08e8cd00e2ed" />


## やっていないこと

## その他
