### PR TITLE
PhotoTipsViewの実装完了

### DIFF
--- a/Zidosuta/View/OnboardingView/OnboardingView.swift
+++ b/Zidosuta/View/OnboardingView/OnboardingView.swift
@@ -32,10 +32,10 @@ struct OnboardingView: View {
   
   
   // MARK: - Properties
-  @StateObject private var model = OnboardingModel()
   @State private var showingNotificationSetting = false
   @State private var showTermsDisplay = false
   @State private var selectedTermsType: TermsDisplayViewController.TermsType?
+  @State private var showNextView = false
   
   
   // MARK: - Body
@@ -88,8 +88,7 @@ struct OnboardingView: View {
               
               Button(
                 action: {
-                  model.transitionToMainContent()
-                  model.completeFirstLaunch()
+                  showNextView = true
                 },
                 label: {
                   Text("始める")
@@ -124,6 +123,16 @@ struct OnboardingView: View {
           .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
           .dynamicTypeSize(DynamicTypeSize.small...DynamicTypeSize.xLarge)
         }
+        //始めるボタンの遷移のための空View
+        NavigationLink(
+          isActive: $showNextView ,
+          destination: {
+            PhotoTipsView()
+          },
+          label: {
+            EmptyView()
+          }
+                )
       }
       .navigationBarHidden(true)
       .accentColor(.white)

--- a/Zidosuta/View/OnboardingView/PhotoTipsView.swift
+++ b/Zidosuta/View/OnboardingView/PhotoTipsView.swift
@@ -10,123 +10,117 @@ import SwiftUI
 struct PhotoTipsView: View {
   
   
+  // MARK: - Properties
+  @StateObject private var model = OnboardingModel()
+  
+  
   // MARK: - Body
   
   var body: some View {
-    GeometryReader { outerGeometry in
-      ZStack {
-        Color("YellowishRed")
-          .ignoresSafeArea()
+    NavigationView {
+      GeometryReader { outerGeometry in
         ZStack {
-          Color("OysterWhite")
-          GeometryReader { geometry in
-            
-            VStack(alignment: .center) {
-              Text("写真撮影のコツ")
-                .font(.custom("Thonburi-Bold", size: geometry.size.width * 0.08, relativeTo: .body))
-                .foregroundStyle(.black)
-                .minimumScaleFactor(0.5)
-                .padding(.top, 50)
+          Color("YellowishRed")
+            .ignoresSafeArea()
+          ZStack {
+            Color("OysterWhite")
+            GeometryReader { geometry in
               
-              VStack {
-                Text(createAttributedString())
-                  .font(.custom("Thonburi", size: geometry.size.width * 0.04, relativeTo: .body))
-                
-                Text("鏡越しの撮影や誰かに撮ってもらうのもオススメです")
-                  .font(.custom("Thonburi", size: geometry.size.width * 0.04, relativeTo: .body))
-              }
-              .padding(.top, 5)
-              .padding(.leading, 1)
-              .padding(.trailing, 1)
-              
-              HStack(alignment: .top) {
-                VStack {
-                  Image("WholeBody")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: geometry.size.width * 0.45)
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
-                  
-                  Image(systemName: "circle")
-                    .foregroundStyle(.blue)
-                    .font(.system(size: 40))
-                    .padding(.top, 8)
-                }
-                .padding(.leading, 5)
-                .padding(.trailing, 5)
+              VStack(alignment: .center) {
+                Text("写真撮影のコツ")
+                  .font(.custom("Thonburi-Bold", size: geometry.size.width * 0.08, relativeTo: .body))
+                  .foregroundStyle(.black)
+                  .minimumScaleFactor(0.5)
+                  .padding(.top, 50)
                 
                 VStack {
-                  Image("HalfBody")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: geometry.size.width * 0.45)
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
+                  Text(createAttributedString())
+                    .font(.custom("Thonburi", size: geometry.size.width * 0.04, relativeTo: .body))
                   
-                  Image(systemName: "triangle")
-                    .foregroundStyle(.red)
-                    .font(.system(size: 40))
-                    .padding(.top, 8)
+                  Text("鏡越しの撮影や誰かに撮ってもらうのもオススメです")
+                    .font(.custom("Thonburi", size: geometry.size.width * 0.04, relativeTo: .body))
                 }
-                .padding(.trailing, 5)
-              }
-              .padding(.top, 30)
-              
-              Spacer()
-              
-              HStack {
-                Button("もどる") {
-                  //ボタン押下時の処理
+                .padding(.top, 5)
+                .padding(.leading, 1)
+                .padding(.trailing, 1)
+                
+                HStack(alignment: .top) {
+                  VStack {
+                    Image("WholeBody")
+                      .resizable()
+                      .scaledToFit()
+                      .frame(width: geometry.size.width * 0.45)
+                      .clipShape(RoundedRectangle(cornerRadius: 15))
+                    
+                    Image(systemName: "circle")
+                      .foregroundStyle(.blue)
+                      .font(.system(size: 40))
+                      .padding(.top, 8)
+                  }
+                  .padding(.leading, 5)
+                  .padding(.trailing, 5)
+                  
+                  VStack {
+                    Image("HalfBody")
+                      .resizable()
+                      .scaledToFit()
+                      .frame(width: geometry.size.width * 0.45)
+                      .clipShape(RoundedRectangle(cornerRadius: 15))
+                    
+                    Image(systemName: "triangle")
+                      .foregroundStyle(.red)
+                      .font(.system(size: 40))
+                      .padding(.top, 8)
+                  }
+                  .padding(.trailing, 5)
                 }
-                .frame(width: 80, height: 40)
-                .foregroundStyle(.gray)
-                .padding(.leading, 20)
+                .padding(.top, 30)
                 
                 Spacer()
                 
-                Button (action:  {
-                  //ボタン押下時の処理
-                },
-                        label:  {
+                HStack {
                   
-                  Text("OK")
-                    .font(.custom("Thonburi-Bold", size: geometry.size.width * 0.0533, relativeTo: .body))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 50)
-                    .padding(.vertical, 15)
-                })
-                .background(Color("YellowishRed"))
-                .cornerRadius(10)
-                .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
-                
-                Spacer()
-                
-                Color.clear
-                  .frame(width: 80, height: 40)
-                  .padding(.trailing, 20)
-                
+                  
+                  Button (action:  {
+                    model.transitionToMainContent()
+                    model.completeFirstLaunch()
+                  },
+                          label:  {
+                    
+                    Text("OK")
+                      .font(.custom("Thonburi-Bold", size: geometry.size.width * 0.0533, relativeTo: .body))
+                      .foregroundStyle(.white)
+                      .padding(.horizontal, 50)
+                      .padding(.vertical, 15)
+                  })
+                  .background(Color("YellowishRed"))
+                  .cornerRadius(10)
+                  .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
+                }
+                .padding(.bottom, 30)
+                .padding(.top, 10)
               }
-              .padding(.bottom, 30)
-              .padding(.top, 10)
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
           }
+          .cornerRadius(10)
+          .padding(.top, calculateVerticalMargin(for: outerGeometry.size))
+          .padding(.bottom, calculateVerticalMargin(for: outerGeometry.size))
+          .padding(.leading, 10)
+          .padding(.trailing,10)
         }
-        .cornerRadius(10)
-        .padding(.top, calculateVerticalMargin(for: outerGeometry.size))
-        .padding(.bottom, calculateVerticalMargin(for: outerGeometry.size))
-        .padding(.leading, 10)
-        .padding(.trailing,10)
       }
     }
   }
   
   
   // MARK: - Method
+  
   //外側のYellowishRedの領域の高さの設定
   private func calculateVerticalMargin(for screenSize: CGSize) -> CGFloat {
     
     let screenHeight = screenSize.height
-  
+    
     let baseRatio: CGFloat = 0.050
     
     //許容される最小、最大の余白サイズ
@@ -141,12 +135,12 @@ struct PhotoTipsView: View {
 }
 
 private func createAttributedString() -> AttributedString {
+  
   var attributedString = AttributedString("全身が映るように撮ると変化が分かりやすくなります")
   
   if let range = attributedString.range(of: "全身が映るように撮る") {
     attributedString[range].foregroundColor = .red
   }
-  
   return attributedString
 }
 


### PR DESCRIPTION
## issue
close #256 

## やったこと
1.  OnboardingViewの始めるボタン押下時の処理をPhotoTipsviewに移行するように変更した
2. PhotoTipsViewのOKボタン押下時にアプリのトップ画面に遷移するようにした
3.  PhotoTipsViewのもどるボタンの削除
→１の処理を実装時にNavigationBarでの戻るボタンが追加された。他画面のUIと統一感があったほうが良いと感じたため、こちらの戻るボタンを採用することにした。
## UI
![unnamed](https://github.com/user-attachments/assets/46f07b01-0f43-4adb-9b40-ec6149bb12f5)

## やっていないこと
## 今後について
後日再度UIやアプリの挙動を確認し問題なければストアにアップデート申請を提出する。

