### PR TITLE
PhotoTipsViewのNavigationBarを非表示にし、戻るボタンを実装した。

### DIFF
--- a/Zidosuta/View/OnboardingView/OnboardingView.swift
+++ b/Zidosuta/View/OnboardingView/OnboardingView.swift
@@ -91,7 +91,7 @@ struct OnboardingView: View {
                   showNextView = true
                 },
                 label: {
-                  Text("始める")
+                  Text("はじめる")
                     .font(.custom("Thonburi-Bold", size: geometry.size.width * 0.0533, relativeTo: .body))
                     .foregroundStyle(.white)
                     .padding(.horizontal, 100)

--- a/Zidosuta/View/OnboardingView/PhotoTipsView.swift
+++ b/Zidosuta/View/OnboardingView/PhotoTipsView.swift
@@ -79,7 +79,14 @@ struct PhotoTipsView: View {
                 Spacer()
                 
                 HStack {
+                  Button("もどる") {
+                    //ボタン押下時の処理
+                  }
+                  .frame(width: 80, height: 40)
+                  .foregroundStyle(.gray)
+                  .padding(.leading, 20)
                   
+                  Spacer()
                   
                   Button (action:  {
                     model.transitionToMainContent()
@@ -96,6 +103,13 @@ struct PhotoTipsView: View {
                   .background(Color("YellowishRed"))
                   .cornerRadius(10)
                   .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
+                  
+                  Spacer()
+                  
+                  Color.clear
+                    .frame(width: 80, height: 40)
+                    .padding(.trailing, 20)
+                  
                 }
                 .padding(.bottom, 30)
                 .padding(.top, 10)
@@ -111,6 +125,7 @@ struct PhotoTipsView: View {
         }
       }
     }
+    .navigationBarHidden(true)
   }
   
   

--- a/Zidosuta/View/OnboardingView/PhotoTipsView.swift
+++ b/Zidosuta/View/OnboardingView/PhotoTipsView.swift
@@ -12,6 +12,7 @@ struct PhotoTipsView: View {
   
   // MARK: - Properties
   @StateObject private var model = OnboardingModel()
+  @Environment(\.dismiss) private var dismiss
   
   
   // MARK: - Body
@@ -80,7 +81,7 @@ struct PhotoTipsView: View {
                 
                 HStack {
                   Button("もどる") {
-                    //ボタン押下時の処理
+                    dismiss()
                   }
                   .frame(width: 80, height: 40)
                   .foregroundStyle(.gray)


### PR DESCRIPTION
## issue
close #258 
## やったこと
- NavigationBarの非表示。
- 戻るボタンを作成。
- 戻るボタンを押した時にOnboardingViewに遷移するようにした。
- OnboardingViewの始めるボタンのラベルを"はじめる"にした。

## UI
iPhoneSE
<img width="222" alt="スクリーンショット 2025-06-05 9 51 33" src="https://github.com/user-attachments/assets/622bb288-13ef-4b40-8c68-847f7cb0a344" />


<img width="269" alt="スクリーンショット 2025-06-05 10 22 06" src="https://github.com/user-attachments/assets/bae57984-d6d0-4400-854e-31cf9e3346ff" />


iPhone16 ProMax
<img width="247" alt="スクリーンショット 2025-06-05 9 50 33" src="https://github.com/user-attachments/assets/8bd4a06e-0f82-452e-be5c-21898be00191" />


<img width="240" alt="スクリーンショット 2025-06-05 10 23 31" src="https://github.com/user-attachments/assets/09293d59-f871-4ede-8d96-d0bd461782fa" />


## やっていないこと

## その他
確認後問題なければAppStoreへのアップデート申請を行う。