### PR TITLE
トップ画面の日付をタップした時に日付選択画面に遷移されるようにした

### DIFF
--- a/Zidosuta/Controller/Other/DateSelectionViewController.swift
+++ b/Zidosuta/Controller/Other/DateSelectionViewController.swift
@@ -53,8 +53,8 @@ class DateSelectionViewController: UIViewController {
       dateSeletionView.tableView.isScrollEnabled = false
       dateSeletionView.tableView.rowHeight = UITableView.automaticDimension
 
-      // ステータスバー部分の背景色の指定
-      setStatusBarBackgroundColor(.YellowishRed)
+      // NavigtionBarの戻るボタンの色を変更
+      self.navigationController?.navigationBar.tintColor = UIColor.white
 
         // Do any additional setup after loading the view.
     }

--- a/Zidosuta/Controller/Top/TopNavigationController.swift
+++ b/Zidosuta/Controller/Top/TopNavigationController.swift
@@ -22,5 +22,6 @@ class TopNavigationController: UINavigationController {
     self.navigationBar.standardAppearance = appearance
     self.navigationBar.scrollEdgeAppearance = appearance
     self.navigationController?.navigationBar.compactAppearance = appearance
+
   }
 }

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -130,6 +130,12 @@ extension TopPageViewController {
 
     // カスタムビューをインスタンス化
     let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 44))
+    customTitleView.translatesAutoresizingMaskIntoConstraints = false
+
+    // ★★【追加】タップジェスチャーを付与 ★★
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(titleViewTapped))
+    customTitleView.isUserInteractionEnabled = true
+    customTitleView.addGestureRecognizer(tapGesture)
 
     // 年の表示形式の設定
     let yearFormatter = DateFormatter()
@@ -176,6 +182,11 @@ extension TopPageViewController {
 
     // AutoLayoutの設定
     NSLayoutConstraint.activate([
+
+      // カスタムビューの領域範囲の制約
+      customTitleView.widthAnchor.constraint(equalToConstant: 200),
+      customTitleView.heightAnchor.constraint(equalToConstant: 44),
+
       // yearTextLabelのY座標の中心はcustomTitleViewのY座標の中心に等しいという制約→つまりNavigationBarのY座標の中心
       yearTextLabel.centerYAnchor.constraint(equalTo: customTitleView.centerYAnchor),
       // この制約については後日確認
@@ -192,6 +203,14 @@ extension TopPageViewController {
     ])
     // カスタムビューをNavigationBarに追加
     self.navigationItem.titleView = customTitleView
+  }
+
+  @objc private func titleViewTapped() {
+      print("タイトルビューがタップされました！")
+
+    let dateSelectionVC = storyboard?.instantiateViewController(identifier: "DateSelection") as! DateSelectionViewController
+
+    navigationController?.pushViewController(dateSelectionVC, animated: true)
   }
 
   // BarButtonの設定

--- a/Zidosuta/View/Base.lproj/Main.storyboard
+++ b/Zidosuta/View/Base.lproj/Main.storyboard
@@ -94,7 +94,7 @@
         <!--Item-->
         <scene sceneID="9pb-3H-LoM">
             <objects>
-                <viewController id="iAn-LN-dAA" customClass="DateSelectionViewController" customModule="Zidosuta" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DateSelection" id="iAn-LN-dAA" customClass="DateSelectionViewController" customModule="Zidosuta" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Mkb-w0-2LF">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
## issue
close #275 
## やったこと
- トップ画面でNavigationBarに表示されている日付をタップした時に、日付選択画面に遷移されるようにした。
- 日付選択画面のNavigationBarの戻るボタンの色を白色に変更。
- 日付選択画面のステータスエリアの背景色を変更する処理を廃止した。（同画面がNavigationControllerにスタックされるため、個別の背景色の変更は不必要になった。なぜならNavigationControllerの背景色はすでに一括で変更されているため。）また、ステータスエリア変更のメソッド自体はUIViewControllerの拡張として残してある。

## 現在の日付選択画面外観

<img width="325" height="682" alt="スクリーンショット 2025-12-11 14 39 21" src="https://github.com/user-attachments/assets/31da1945-5276-44b7-af1c-60e71efad664" />

## やっていないこと
- 遷移に伴う処理（遷移時に日付選択画面に値を渡す処理など。日付選択画面をどのような仕様にするかによって変わるかため要検討）
- グラフ画面での同様の機能の実装
