### PR TITLE
日付設定画面にデフォルトの値が表示されるようにした

### DIFF
--- a/Zidosuta/Controller/Other/DateSelectionViewController.swift
+++ b/Zidosuta/Controller/Other/DateSelectionViewController.swift
@@ -107,6 +107,11 @@ extension DateSelectionViewController: UITableViewDelegate, UITableViewDataSourc
     case 0:
       if cell == .selectedDateDisplayTableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SelectedDateDisplayTableViewCell", for: indexPath) as! SelectedDateDisplayTableViewCell
+
+        let defaultDate = Date()
+        let combinedString = defaultDate.convertDateToSelectedDateString()
+        cell.dateLabel.text = combinedString
+
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
         return cell
       } else {

--- a/Zidosuta/Utilitis/Extensions/Date + ConvertDateToNotificationTimeString.swift
+++ b/Zidosuta/Utilitis/Extensions/Date + ConvertDateToNotificationTimeString.swift
@@ -20,4 +20,19 @@ extension Date {
     let combinedString = ("\(paddedHour) : \(paddedMinute)")
     return combinedString
   }
+
+  func convertDateToSelectedDateString() -> String {
+
+    let calendar = Calendar.current
+
+    let year = calendar.component(.year, from: self)
+    let month = calendar.component(.month, from: self)
+    let day = calendar.component(.day, from: self)
+
+    let paddedMonth = String(format: "%02d", month)
+    let paddedDay = String(format: "%02d", day)
+
+    let combinedString = "\(year)年 \(paddedMonth)月 \(paddedDay)日"
+    return combinedString
+  }
 }


### PR DESCRIPTION
## issue
close #277 
## やったこと
- 選択されている日付を表示する部分に今日の日付がデフォルトで表示されるようにした。
（ピッカーはすでに今日の日付が表示されている仕様だった）

## 日付選択画面外観
遷移直後の外観
<img width="334" height="680" alt="スクリーンショット 2025-12-11 23 48 54" src="https://github.com/user-attachments/assets/03a317ee-9f0c-403f-b628-e8594644ef41" />
