### PR TITLE
日付選択画面で日付を選択後、トップ画面で前のページにスワイプで戻ったときに間違った日付が表示されてしまうバグを修正した

### DIFF
--- a/Zidosuta/Controller/Graph/GraphPageViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphPageViewController.swift
@@ -47,7 +47,7 @@ class GraphPageViewController: UIPageViewController {
 
     self.controllers = [graphVC]
 
-    setViewControllers([self.controllers[0]], direction: .forward, animated: true, completion: nil)
+    setViewControllers([self.controllers[0]], direction: .forward, animated: false, completion: nil)
 
     self.dataSource = self
   }

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -45,7 +45,7 @@ class TopPageViewController: UIPageViewController {
 
     let topVC = storyboard!.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
     self.controllers = [topVC]
-    setViewControllers([self.controllers[0]], direction: .forward, animated: true, completion: nil)
+    setViewControllers([self.controllers[0]], direction: .forward, animated: false, completion: nil)
   }
 }
 
@@ -216,15 +216,15 @@ extension TopPageViewController {
         print("新しい日付の取得エラー")
         return
       }
-      
+
       //　新しい日付で TopViewControllerを再生成しセット
       let newDateVC = storyboard!.instantiateViewController(withIdentifier: "TopVC") as! TopViewController
       newDateVC.topDateManager.exchangeDate(newDate: newDate)
       self.controllers = [newDateVC]
-      //NavigationBarの表示も再設定
+      // NavigationBarの表示も再設定
       self.navigationBarTitleSetting(currentDate: newDateVC.topDateManager.date)
       self.navigationBarButtonSetting()
-      setViewControllers([self.controllers[0]], direction: .forward, animated: true, completion: nil)
+      setViewControllers([self.controllers[0]], direction: .forward, animated: false, completion: nil)
     }
     navigationController?.pushViewController(dateSelectionVC, animated: true)
   }


### PR DESCRIPTION
## issue
close #284 
## やったこと
- TopPageViewControllerのsetViewControllers(_:direction:animated:completion:)を呼ぶときにanimatedをfalseとした。（NavigationBarの矢印ボタン押下時を除く）
これでバグが発生しなくなった。
## なぜこの修正をしたか
下記の記事を参考にした。
https://stackoverflow.com/questions/12939280/uipageviewcontroller-navigates-to-wrong-page-with-scroll-transition-style/40942311#40942311

おそらくanimatedをtrueにしたときにPageViewControllerが内部でページをキャッシュすることが影響しているので、animatedをfalseとしたらバグが発生しなくなった。現状ではsetViewControllers(_:direction:animated:completion:)を呼んだときに
アニメーションさせる必要がない（NavigationBarの矢印ボタン押下時を除く）のでとりあえずこの方法で様子を見ることにする。現状ではNavigationBarの矢印ボタンでの遷移時にはバグが発生していない。
