### PR TITLE
通知処理とそのテストコードのリファレンスの保留

### DIFF
--- a/ZidosutaTests/ModelTests/LocalNotificationManagerTests.swift
+++ b/ZidosutaTests/ModelTests/LocalNotificationManagerTests.swift
@@ -8,6 +8,15 @@
 import XCTest
 @testable import Zidosuta
 
+// 2025.12 備忘録
+// 現在以下のテストは失敗する
+// 現在のLocalNotificationManagerがテスト不能な仕様になっているため
+// なので将来的にLocalNotificationManagerとテストの大幅なリファレンスが必要だと考えられる
+// テスト不能の理由として、考えられる理由を以下に残しておく
+// 1. テストではユーザーへ通知の許可（アラートでユーザーに通知権限の問い合わせを行うやつ）を求めることができないから。
+//    そのため常に通知権限のステータスが.authorized（許可）にならず、許可された場合の処理が実行されない
+// 2. LocalNotificationManagerの通知登録処理が非同期処理だが、この処理にcompletion（テストで登録の検証を行う処理など）を渡すことができるような仕様になっていないため
+
 class LocalNotificationManagerTests: XCTestCase {
 
   // MARK: - Properties


### PR DESCRIPTION
## issue
close #290 
## やったこと
- 通知処理とそのテストコードのリファレンスの保留

## 保留理由
- 現在のLocalNotificationManagerがテスト不能な仕様になっており、テストコードを含めたリファレンスに時間がかかりそうだから（テストファイルに備忘録あり）
-  CI/CDパイプラインの構築を優先したいため
- 通知処理の作成時にXCTestを使わない方法で検証を行っており、現段階で不具合も確認されていないため、今すぐ対応する必要はないと判断したため
