### PR TITLE
change: CI/CD時に利用するXCodeを安定最新版である26.3に変更

### DIFF
--- a/.github/workflows/zidosuta-cd.yml
+++ b/.github/workflows/zidosuta-cd.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.4"
-
-      - name: Install iOS Simulator Runtime
-        run: xcodebuild -downloadPlatform iOS
+          xcode-version: "26.3"
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/zidosuta-ci.yml
+++ b/.github/workflows/zidosuta-ci.yml
@@ -18,10 +18,8 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.4"
-      - name: Install iOS Simulator Runtime
-        run: xcodebuild -downloadPlatform iOS
-
+          xcode-version: "26.3"
+          
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.2


### PR DESCRIPTION
## issue
close #319 
## やったこと
- CI/CD時に利用するXCodeのverを安定最新版の26.3に変更

