### PR TITLE
NavigtationBar内のUIBarButtonItemをLiquidGlassに対応させた

### DIFF
--- a/Zidosuta.xcodeproj/project.pbxproj
+++ b/Zidosuta.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */; };
 		FA5DF1C92D3CFB6A006F5ECA /* UIButton+AdjustmentOfappearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF1C82D3CFB6A006F5ECA /* UIButton+AdjustmentOfappearance.swift */; };
 		FA61F05C2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA61F05B2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift */; };
+		FA61F0612FC3FA9400E7D7F1 /* UIBarButtonItem+LiquidGlassSupporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA61F0602FC3FA9400E7D7F1 /* UIBarButtonItem+LiquidGlassSupporting.swift */; };
 		FA6674CB2F923D870032FB36 /* AppInfoString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6674CA2F923D870032FB36 /* AppInfoString.swift */; };
 		FA6674D12F9BA1FC0032FB36 /* TopNavigationBarString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6674D02F9BA1FC0032FB36 /* TopNavigationBarString.swift */; };
 		FA6674D72FA102080032FB36 /* GraphMarkerString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6674D62FA102080032FB36 /* GraphMarkerString.swift */; };
@@ -207,6 +208,7 @@
 		FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphContentCreator.swift; sourceTree = "<group>"; };
 		FA5DF1C82D3CFB6A006F5ECA /* UIButton+AdjustmentOfappearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+AdjustmentOfappearance.swift"; sourceTree = "<group>"; };
 		FA61F05B2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassSupporting.swift; sourceTree = "<group>"; };
+		FA61F0602FC3FA9400E7D7F1 /* UIBarButtonItem+LiquidGlassSupporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+LiquidGlassSupporting.swift"; sourceTree = "<group>"; };
 		FA6674CA2F923D870032FB36 /* AppInfoString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoString.swift; sourceTree = "<group>"; };
 		FA6674D02F9BA1FC0032FB36 /* TopNavigationBarString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationBarString.swift; sourceTree = "<group>"; };
 		FA6674D62FA102080032FB36 /* GraphMarkerString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphMarkerString.swift; sourceTree = "<group>"; };
@@ -509,6 +511,14 @@
 			path = TopPageTextFieldValidationTest;
 			sourceTree = "<group>";
 		};
+		FA61F05D2FC3FA1C00E7D7F1 /* LiquidGlassSupporting */ = {
+			isa = PBXGroup;
+			children = (
+				FA61F0602FC3FA9400E7D7F1 /* UIBarButtonItem+LiquidGlassSupporting.swift */,
+			);
+			path = LiquidGlassSupporting;
+			sourceTree = "<group>";
+		};
 		FA6674C92F923D310032FB36 /* Constant */ = {
 			isa = PBXGroup;
 			children = (
@@ -718,6 +728,7 @@
 		FA9F9CE52CF44E690013886A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				FA61F05D2FC3FA1C00E7D7F1 /* LiquidGlassSupporting */,
 				FA9F9CE32CF449030013886A /* UIColor+AppThemeColor.swift */,
 				FA5DF1C82D3CFB6A006F5ECA /* UIButton+AdjustmentOfappearance.swift */,
 				FA9F9CEA2CF5A6CC0013886A /* ChartAxisBase+setKGFormatter.swift */,
@@ -1309,6 +1320,7 @@
 				FADD2CE32FB610170084D5D0 /* PhotoTipsString.swift in Sources */,
 				FAC9EF2A2D0C11A000DE1E64 /* DateData.swift in Sources */,
 				FAC9EF2B2D0C11A000DE1E64 /* Settings.swift in Sources */,
+				FA61F0612FC3FA9400E7D7F1 /* UIBarButtonItem+LiquidGlassSupporting.swift in Sources */,
 				FA87004A2F7A55F60067EAD5 /* NibLoadable.swift in Sources */,
 				FAC9EF222D0C0B5C00DE1E64 /* TopNavigationController.swift in Sources */,
 				FA61F05C2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift in Sources */,

--- a/Zidosuta.xcodeproj/project.pbxproj
+++ b/Zidosuta.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		FA42FA522A81D8CC00C60F9E /* CustomMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA42FA512A81D8CC00C60F9E /* CustomMarkerView.swift */; };
 		FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */; };
 		FA5DF1C92D3CFB6A006F5ECA /* UIButton+AdjustmentOfappearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DF1C82D3CFB6A006F5ECA /* UIButton+AdjustmentOfappearance.swift */; };
+		FA61F05C2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA61F05B2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift */; };
 		FA6674CB2F923D870032FB36 /* AppInfoString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6674CA2F923D870032FB36 /* AppInfoString.swift */; };
 		FA6674D12F9BA1FC0032FB36 /* TopNavigationBarString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6674D02F9BA1FC0032FB36 /* TopNavigationBarString.swift */; };
 		FA6674D72FA102080032FB36 /* GraphMarkerString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6674D62FA102080032FB36 /* GraphMarkerString.swift */; };
@@ -205,6 +206,7 @@
 		FA42FA512A81D8CC00C60F9E /* CustomMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMarkerView.swift; sourceTree = "<group>"; };
 		FA4D29A22A64F93900C2C5E6 /* GraphContentCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphContentCreator.swift; sourceTree = "<group>"; };
 		FA5DF1C82D3CFB6A006F5ECA /* UIButton+AdjustmentOfappearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+AdjustmentOfappearance.swift"; sourceTree = "<group>"; };
+		FA61F05B2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassSupporting.swift; sourceTree = "<group>"; };
 		FA6674CA2F923D870032FB36 /* AppInfoString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoString.swift; sourceTree = "<group>"; };
 		FA6674D02F9BA1FC0032FB36 /* TopNavigationBarString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationBarString.swift; sourceTree = "<group>"; };
 		FA6674D62FA102080032FB36 /* GraphMarkerString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphMarkerString.swift; sourceTree = "<group>"; };
@@ -653,6 +655,7 @@
 			isa = PBXGroup;
 			children = (
 				FA8700492F7A55F50067EAD5 /* NibLoadable.swift */,
+				FA61F05B2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1308,6 +1311,7 @@
 				FAC9EF2B2D0C11A000DE1E64 /* Settings.swift in Sources */,
 				FA87004A2F7A55F60067EAD5 /* NibLoadable.swift in Sources */,
 				FAC9EF222D0C0B5C00DE1E64 /* TopNavigationController.swift in Sources */,
+				FA61F05C2FC3F89300E7D7F1 /* LiquidGlassSupporting.swift in Sources */,
 				FAA9E72F2FA4E7B100CBED1E /* SettingsNavigationBarString.swift in Sources */,
 				FAA9E7412FA6291E00CBED1E /* DeletionAlertString.swift in Sources */,
 				FACA1A542D2BE5EB00B2768D /* TermsTextView.swift in Sources */,

--- a/Zidosuta/Controller/Graph/GraphPageViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphPageViewController.swift
@@ -185,12 +185,18 @@ extension GraphPageViewController {
   // barButtonの設定
   private func navigationBarButtonSetting() {
 
-    let nextBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.right"), style: .done, target: self, action: #selector(buttonPaging(_:)))
+    let arrowRight = UIImage(systemName: "arrow.right")?
+        .withTintColor(.white, renderingMode: .alwaysOriginal)
+    let arrowLeft = UIImage(systemName: "arrow.left")?
+        .withTintColor(.white, renderingMode: .alwaysOriginal)
+
+    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .done, target: self, action: #selector(buttonPaging(_:)))
     nextBarButtonItem.tag = 1
-    nextBarButtonItem.tintColor = .white
-    let previousBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .done, target: self, action: #selector(buttonPaging(_:)))
+    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .done, target: self, action: #selector(buttonPaging(_:)))
     previousBarButtonItem.tag = 2
-    previousBarButtonItem.tintColor = .white
+
+    nextBarButtonItem.applyLiquidGlass()
+    previousBarButtonItem.applyLiquidGlass()
 
     self.navigationItem.rightBarButtonItem = nextBarButtonItem
     self.navigationItem.leftBarButtonItem = previousBarButtonItem

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -239,17 +239,34 @@ extension TopPageViewController {
   // BarButtonの設定
   private func navigationBarButtonSetting() {
 
-    let nextBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.right"), style: .plain, target: self, action: #selector(buttonPaging(_:)))
-    nextBarButtonItem.tag = 1
-    nextBarButtonItem.tintColor = .white
-    let previousBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .plain, target: self, action: #selector(buttonPaging(_:)))
-    previousBarButtonItem.tag = 2
-    previousBarButtonItem.tintColor = .white
+    // arrow.right等の色は、そのままLiquid Glassと組み合わせるとUIBarButtonItem(image:で指定したときに肌色っぽくなる。
+    // なのでSFSymbolの初期化時に白色を明示し、renderingMode: .alwaysOriginal
+    let arrowRight = UIImage(systemName: "arrow.right")?
+        .withTintColor(.white, renderingMode: .alwaysOriginal)
+    let arrowLeft = UIImage(systemName: "arrow.left")?
+        .withTintColor(.white, renderingMode: .alwaysOriginal)
 
-    if #available(iOS 26.0, *) {
-      nextBarButtonItem.hidesSharedBackground = true
-      previousBarButtonItem.hidesSharedBackground = true
+    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .plain, target: self, action: #selector(buttonPaging(_:)))
+    nextBarButtonItem.tag = 1
+    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .plain, target: self, action: #selector(buttonPaging(_:)))
+    previousBarButtonItem.tag = 2
+
+
+    // Liquid Glass対応
+    if #available(iOS 26, *) {
+      nextBarButtonItem.style = .prominent
+      nextBarButtonItem.tintColor = .YellowishRed
+
+      previousBarButtonItem.style = .prominent
+      previousBarButtonItem.tintColor = .YellowishRed
     }
+
+    // Liquid Glassのガラス背景を無効化し、見た目を以前のものと同様にする
+
+//    if #available(iOS 26.0, *) {
+//      nextBarButtonItem.hidesSharedBackground = true
+//      previousBarButtonItem.hidesSharedBackground = true
+//    }
 
     self.navigationItem.rightBarButtonItem = nextBarButtonItem
     self.navigationItem.leftBarButtonItem = previousBarButtonItem

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -239,12 +239,17 @@ extension TopPageViewController {
   // BarButtonの設定
   private func navigationBarButtonSetting() {
 
-    let nextBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.right"), style: .done, target: self, action: #selector(buttonPaging(_:)))
+    let nextBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.right"), style: .plain, target: self, action: #selector(buttonPaging(_:)))
     nextBarButtonItem.tag = 1
     nextBarButtonItem.tintColor = .white
-    let previousBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .done, target: self, action: #selector(buttonPaging(_:)))
+    let previousBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .plain, target: self, action: #selector(buttonPaging(_:)))
     previousBarButtonItem.tag = 2
     previousBarButtonItem.tintColor = .white
+
+    if #available(iOS 26.0, *) {
+      nextBarButtonItem.hidesSharedBackground = true
+      previousBarButtonItem.hidesSharedBackground = true
+    }
 
     self.navigationItem.rightBarButtonItem = nextBarButtonItem
     self.navigationItem.leftBarButtonItem = previousBarButtonItem

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -253,13 +253,8 @@ extension TopPageViewController {
 
 
     // Liquid Glass対応
-    if #available(iOS 26, *) {
-      nextBarButtonItem.style = .prominent
-      nextBarButtonItem.tintColor = .YellowishRed
-
-      previousBarButtonItem.style = .prominent
-      previousBarButtonItem.tintColor = .YellowishRed
-    }
+    nextBarButtonItem.applyLiquidGlass()
+    previousBarButtonItem.applyLiquidGlass()
 
     // Liquid Glassのガラス背景を無効化し、見た目を以前のものと同様にする
 

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -240,7 +240,7 @@ extension TopPageViewController {
   private func navigationBarButtonSetting() {
 
     // arrow.right等の色は、そのままLiquid Glassと組み合わせるとUIBarButtonItem(image:で指定したときに肌色っぽくなる。
-    // なのでSFSymbolの初期化時に白色を明示し、renderingMode: .alwaysOriginal
+    // なのでSFSymbolの初期化時に白色を明示し、renderingMode: .alwaysOriginalでオリジナルのままのレンダリングを指定する
     let arrowRight = UIImage(systemName: "arrow.right")?
         .withTintColor(.white, renderingMode: .alwaysOriginal)
     let arrowLeft = UIImage(systemName: "arrow.left")?

--- a/Zidosuta/Info.plist
+++ b/Zidosuta/Info.plist
@@ -42,6 +42,6 @@
 		</dict>
 	</dict>
 	<key>UIDesignRequiresCompatibility</key>
-	<true/>
+	<false/>
 </dict>
 </plist>

--- a/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
+++ b/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
@@ -1,0 +1,25 @@
+//
+//  UIBarButtonItem+LiquidGlassSupporting.swift
+//  Zidosuta
+//
+//  Created by 川島真之 on 2026/05/25.
+//
+
+import Foundation
+import UIKit
+
+extension UIBarButtonItem: LiquidGlassSupporting {
+
+  func applyLiquidGlass() {
+    if #available(iOS 26, *) {
+      style = .prominent
+      tintColor = .YellowishRed
+    }
+  }
+
+  func revertLiquidGlass() {
+    if #available(iOS 26.0, *) {
+      hidesSharedBackground = true
+    }
+  }
+}

--- a/Zidosuta/View/Base/LiquidGlassSupporting.swift
+++ b/Zidosuta/View/Base/LiquidGlassSupporting.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 protocol LiquidGlassSupporting {
 
   func applyLiquidGlass()

--- a/Zidosuta/View/Base/LiquidGlassSupporting.swift
+++ b/Zidosuta/View/Base/LiquidGlassSupporting.swift
@@ -1,0 +1,14 @@
+//
+//  LiquidGlassSupporting.swift
+//  Zidosuta
+//
+//  Created by 川島真之 on 2026/05/25.
+//
+
+import Foundation
+
+protocol LiquidGlassSupporting {
+
+  func applyLiquidGlass()
+  func revertLiquidGlass()
+}


### PR DESCRIPTION
## issue
close #332
## やったこと
- NavigtationBar内のUIBarButtonItemをLiquidGlassに対応させ、UIを変更した
- LiquidGlassを無効化し、前のUI(iOS18以前のUI)に戻す処理も作成した

## UI比較
**対応前（XCode26でビルドした崩れたレイアウト)**
<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-24 at 12 36 31" src="https://github.com/user-attachments/assets/5f842f95-4039-4c41-9814-1bae5f2cc5a4" />

<img width="1266" height="585" alt="Simulator Screenshot - iPhone 17e - 2026-05-24 at 12 37 16" src="https://github.com/user-attachments/assets/172f45eb-d978-4af4-9fd4-feba4432dbaf" />

**対応後**

<img width="375" height="667" alt="Simulator Screenshot - iPhone SE 3rd - 2026-05-25 at 17 00 54" src="https://github.com/user-attachments/assets/37935cc3-93af-4c01-8776-e8ea511c3b2f" />

<img width="667" height="375" alt="Simulator Screenshot - iPhone SE 3rd - 2026-05-25 at 12 57 06" src="https://github.com/user-attachments/assets/7b8ae03d-714b-4f1f-8ad9-ea5f280c9955" />
