### PR TITLE
Top画面のLiquidGlass対応や新レイアウト作業を行なった

### DIFF
--- a/Zidosuta.xcodeproj/project.pbxproj
+++ b/Zidosuta.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		FA9F9CE42CF449030013886A /* UIColor+AppThemeColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9F9CE32CF449030013886A /* UIColor+AppThemeColor.swift */; };
 		FA9F9CEB2CF5A6CC0013886A /* ChartAxisBase+setKGFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9F9CEA2CF5A6CC0013886A /* ChartAxisBase+setKGFormatter.swift */; };
 		FA9F9CED2CF5A8540013886A /* TransitionDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9F9CEC2CF5A8540013886A /* TransitionDirection.swift */; };
+		FAA860922FC7E65200F22CCF /* UIBarButtonItem+IconFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA860912FC7E65200F22CCF /* UIBarButtonItem+IconFactory.swift */; };
 		FAA926A82DED6AA000608AA6 /* OnboardingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA926A72DED6AA000608AA6 /* OnboardingModel.swift */; };
 		FAA926AA2DEDBD9300608AA6 /* PhotoTipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA926A92DEDBD9300608AA6 /* PhotoTipsView.swift */; };
 		FAA9E72F2FA4E7B100CBED1E /* SettingsNavigationBarString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9E72E2FA4E7B100CBED1E /* SettingsNavigationBarString.swift */; };
@@ -256,6 +257,7 @@
 		FA9F9CE32CF449030013886A /* UIColor+AppThemeColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+AppThemeColor.swift"; sourceTree = "<group>"; };
 		FA9F9CEA2CF5A6CC0013886A /* ChartAxisBase+setKGFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChartAxisBase+setKGFormatter.swift"; sourceTree = "<group>"; };
 		FA9F9CEC2CF5A8540013886A /* TransitionDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionDirection.swift; sourceTree = "<group>"; };
+		FAA860912FC7E65200F22CCF /* UIBarButtonItem+IconFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+IconFactory.swift"; sourceTree = "<group>"; };
 		FAA926A72DED6AA000608AA6 /* OnboardingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModel.swift; sourceTree = "<group>"; };
 		FAA926A92DEDBD9300608AA6 /* PhotoTipsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTipsView.swift; sourceTree = "<group>"; };
 		FAA9E72E2FA4E7B100CBED1E /* SettingsNavigationBarString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationBarString.swift; sourceTree = "<group>"; };
@@ -734,6 +736,7 @@
 				FA9F9CEA2CF5A6CC0013886A /* ChartAxisBase+setKGFormatter.swift */,
 				FAC0A8A72D06D3010074D818 /* Date+ConvertDateToNotificationTimeString.swift */,
 				FA80692D2EE7F59A0013CBB3 /* UIViewController+setStatusBarBackgroundColor.swift */,
+				FAA860912FC7E65200F22CCF /* UIBarButtonItem+IconFactory.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1368,6 +1371,7 @@
 				FAAB98582D1865410034F243 /* ContactTableViewCell.swift in Sources */,
 				FA9F9CEB2CF5A6CC0013886A /* ChartAxisBase+setKGFormatter.swift in Sources */,
 				FA417BC02A5C428E00B53A0F /* DateDataRealmSearcher.swift in Sources */,
+				FAA860922FC7E65200F22CCF /* UIBarButtonItem+IconFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Zidosuta/Assets.xcassets/CustomBlue.colorset/Contents.json
+++ b/Zidosuta/Assets.xcassets/CustomBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.478",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.478",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Zidosuta/Controller/Graph/CustomMarkerViewController.swift
+++ b/Zidosuta/Controller/Graph/CustomMarkerViewController.swift
@@ -187,6 +187,6 @@ class CustomMarkerViewController: UIViewController, CustomMarkerViewDataSource {
   // 色を指定
   func markerBackGroundColor(in customMarkerView: CustomMarkerView) -> UIColor {
 
-    return UIColor.CornflowerBlue
+    return UIColor.cornflowerBlue
   }
 }

--- a/Zidosuta/Controller/Graph/GraphNavigationController.swift
+++ b/Zidosuta/Controller/Graph/GraphNavigationController.swift
@@ -28,7 +28,7 @@ class GraphNavigationController: UINavigationController {
     // Do any additional setup after loading the view.
     let appearance = UINavigationBarAppearance()
     appearance.configureWithOpaqueBackground()
-    appearance.backgroundColor = UIColor.YellowishRed
+    appearance.backgroundColor = UIColor.yellowishRed
 
     self.navigationBar.standardAppearance = appearance
     self.navigationBar.scrollEdgeAppearance = appearance

--- a/Zidosuta/Controller/Graph/GraphPageViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphPageViewController.swift
@@ -195,8 +195,8 @@ extension GraphPageViewController {
     let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .done, target: self, action: #selector(buttonPaging(_:)))
     previousBarButtonItem.tag = 2
 
-    nextBarButtonItem.applyLiquidGlass()
-    previousBarButtonItem.applyLiquidGlass()
+    nextBarButtonItem.adjustLiquidGlass()
+    previousBarButtonItem.adjustLiquidGlass()
 
     self.navigationItem.rightBarButtonItem = nextBarButtonItem
     self.navigationItem.leftBarButtonItem = previousBarButtonItem

--- a/Zidosuta/Controller/Graph/GraphViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphViewController.swift
@@ -186,9 +186,9 @@ extension GraphViewController {
     let xAxisLabelFont = UIFont(name: "Thonburi-Bold", size: 12)
     xAxis.labelFont = xAxisLabelFont ?? UIFont.systemFont(ofSize: 12)
     // X軸のラベルのカラーを設定
-    xAxis.labelTextColor = UIColor.CornflowerBlue
+    xAxis.labelTextColor = UIColor.cornflowerBlue
     // X軸の軸線のカラーを設定
-    xAxis.axisLineColor = UIColor.CornflowerBlue
+    xAxis.axisLineColor = UIColor.cornflowerBlue
     // X軸の軸線の太さを設定
     xAxis.axisLineWidth = CGFloat(1.0)
 
@@ -278,8 +278,8 @@ extension GraphViewController {
       leftAxis.axisMaximum = calculatedAxisMax // Y軸の最大値
       leftAxis.setLabelCount(6, force: true)
 
-      let entryPointColor = UIColor.CornflowerBlue
-      let graphLineColor = UIColor.CornflowerBlue.withAlphaComponent(0.5)
+      let entryPointColor = UIColor.cornflowerBlue
+      let graphLineColor = UIColor.cornflowerBlue.withAlphaComponent(0.5)
       // エントリーポイントを二重円ではなく、通常の円にする
       dataSet.drawCircleHoleEnabled = false
       // エントリーポイントのサイズの調整

--- a/Zidosuta/Controller/Settings/SettingsNavigationController.swift
+++ b/Zidosuta/Controller/Settings/SettingsNavigationController.swift
@@ -19,7 +19,7 @@ class SettingsNavigationController: UINavigationController {
     navigationBar.tintColor = .white
     let appearance = UINavigationBarAppearance()
     appearance.configureWithOpaqueBackground()
-    appearance.backgroundColor = UIColor.YellowishRed
+    appearance.backgroundColor = UIColor.yellowishRed
 
     self.navigationBar.standardAppearance = appearance
     self.navigationBar.scrollEdgeAppearance = appearance

--- a/Zidosuta/Controller/Settings/SettingsViewController.swift
+++ b/Zidosuta/Controller/Settings/SettingsViewController.swift
@@ -175,7 +175,7 @@ extension SettingsViewController: UITableViewDelegate, UITableViewDataSource {
         let setDate = Settings.shared.notification?.notificationTime
         let combinedString = setDate?.convertDateToNotificationTimeString()
         cell.statusLabel.text = combinedString
-        cell.statusLabel.textColor = .YellowishRed
+        cell.statusLabel.textColor = .yellowishRed
         // スイッチをオンにする
         cell.notificationSwitch.isOn = true
       } else {
@@ -298,7 +298,7 @@ extension SettingsViewController: NotificationTableViewCellDelegate {
       // 一秒間遅延させる
       // 遅延させないと画面遷移アニメーション中にstatusLabelが.yellowishRedになっていることが見えてしまう
       DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-        cell.statusLabel.textColor = .YellowishRed
+        cell.statusLabel.textColor = .yellowishRed
       }
       // オフにしたら
     } else {

--- a/Zidosuta/Controller/TabBarController.swift
+++ b/Zidosuta/Controller/TabBarController.swift
@@ -22,7 +22,7 @@ class TabBarController: UITabBarController {
     let appearance = UITabBarAppearance()
     appearance.backgroundColor = .white
 
-    UITabBar.appearance().tintColor = UIColor.YellowishRed
+    UITabBar.appearance().tintColor = UIColor.yellowishRed
     UITabBar.appearance().standardAppearance = appearance
     UITabBar.appearance().scrollEdgeAppearance = appearance
     // Do any additional setup after loading the view.

--- a/Zidosuta/Controller/Top/TopNavigationController.swift
+++ b/Zidosuta/Controller/Top/TopNavigationController.swift
@@ -15,14 +15,5 @@ class TopNavigationController: UINavigationController {
   override func viewDidLoad() {
 
     super.viewDidLoad()
-
-    let appearance = UINavigationBarAppearance()
-    appearance.configureWithOpaqueBackground()
-    appearance.backgroundColor = UIColor.YellowishRed
-
-    self.navigationBar.standardAppearance = appearance
-    self.navigationBar.scrollEdgeAppearance = appearance
-    self.navigationController?.navigationBar.compactAppearance = appearance
-
   }
 }

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -239,22 +239,50 @@ extension TopPageViewController {
   // BarButtonの設定
   private func navigationBarButtonSetting() {
 
+    let barIconColor = UIColor.white
+    let backgroundColor = UIColor.YellowishRed
+    let nextTag = 1
+    let previousTag = 2
+    let nextSystemName = "chevron.forward"
+    let previousSystemName = "chevron.backward"
+
+    if #available(iOS 26, *) {
+
+      let nextBarButtonItem = UIBarButtonItem.liquidGlassIcon(systemName: nextSystemName, iconColor: barIconColor, directionTag: nextTag, target: self, action: #selector(buttonPaging(_:)))
+      let previousBarButtonItem = UIBarButtonItem.liquidGlassIcon(systemName: previousSystemName, iconColor: barIconColor, directionTag: previousTag, target: self, action: #selector(buttonPaging(_:)))
+
+      self.navigationItem.rightBarButtonItem = nextBarButtonItem
+      self.navigationItem.leftBarButtonItem = previousBarButtonItem
+    } else {
+
+      let nextBarButtonItem = UIBarButtonItem.roundedIcon(systemName: nextSystemName, iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: nextTag, target: self, action: #selector(buttonPaging(_:)))
+      let previousBarButtonItem = UIBarButtonItem.roundedIcon(systemName: previousSystemName, iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: previousTag, target: self, action: #selector(buttonPaging(_:)))
+
+      self.navigationItem.rightBarButtonItem = nextBarButtonItem
+      self.navigationItem.leftBarButtonItem = previousBarButtonItem
+    }
+
+
     // arrow.right等の色は、そのままLiquid Glassと組み合わせるとUIBarButtonItem(image:で指定したときに肌色っぽくなる。
     // なのでSFSymbolの初期化時に白色を明示し、renderingMode: .alwaysOriginalでオリジナルのままのレンダリングを指定する
-    let arrowRight = UIImage(systemName: "arrow.right")?
-        .withTintColor(.YellowishRed, renderingMode: .alwaysOriginal)
-    let arrowLeft = UIImage(systemName: "arrow.left")?
-        .withTintColor(.YellowishRed, renderingMode: .alwaysOriginal)
+//    let arrowRight = UIImage(systemName: "arrow.right")?
+//        .withTintColor(barIconColor, renderingMode: .alwaysOriginal)
+//    let arrowLeft = UIImage(systemName: "arrow.left")?
+//        .withTintColor(barIconColor
+//                       , renderingMode: .alwaysOriginal)
+//
+//    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .plain, target: self, action: #selector(buttonPaging(_:)))
+//    nextBarButtonItem.tag = 1
+//    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .plain, target: self, action: #selector(buttonPaging(_:)))
+//    previousBarButtonItem.tag = 2
 
-    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .plain, target: self, action: #selector(buttonPaging(_:)))
-    nextBarButtonItem.tag = 1
-    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .plain, target: self, action: #selector(buttonPaging(_:)))
-    previousBarButtonItem.tag = 2
-
-
-    // Liquid Glass対応
-    nextBarButtonItem.applyLiquidGlass()
-    previousBarButtonItem.applyLiquidGlass()
+//    let nextBarButtonItem = UIBarButtonItem.roundedIcon(systemName: "arrow.right", iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: nextTag, target: self, action: #selector(buttonPaging(_:)))
+//
+//    let previousBarButtonItem = UIBarButtonItem.roundedIcon(systemName: "arrow.left", iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: previousTag, target: self, action: #selector(buttonPaging(_:)))
+//
+//    // Liquid Glass対応
+//    nextBarButtonItem.applyLiquidGlass()
+//    previousBarButtonItem.applyLiquidGlass()
 
     // Liquid Glassのガラス背景を無効化し、見た目を以前のものと同様にする
 
@@ -263,8 +291,8 @@ extension TopPageViewController {
 //      previousBarButtonItem.hidesSharedBackground = true
 //    }
 
-    self.navigationItem.rightBarButtonItem = nextBarButtonItem
-    self.navigationItem.leftBarButtonItem = previousBarButtonItem
+//    self.navigationItem.rightBarButtonItem = nextBarButtonItem
+//    self.navigationItem.leftBarButtonItem = previousBarButtonItem
   }
   // BarButton押下時の画面遷移
   @objc func buttonPaging(_ sender: UIBarButtonItem) {

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -242,9 +242,9 @@ extension TopPageViewController {
     // arrow.right等の色は、そのままLiquid Glassと組み合わせるとUIBarButtonItem(image:で指定したときに肌色っぽくなる。
     // なのでSFSymbolの初期化時に白色を明示し、renderingMode: .alwaysOriginalでオリジナルのままのレンダリングを指定する
     let arrowRight = UIImage(systemName: "arrow.right")?
-        .withTintColor(.white, renderingMode: .alwaysOriginal)
+        .withTintColor(.YellowishRed, renderingMode: .alwaysOriginal)
     let arrowLeft = UIImage(systemName: "arrow.left")?
-        .withTintColor(.white, renderingMode: .alwaysOriginal)
+        .withTintColor(.YellowishRed, renderingMode: .alwaysOriginal)
 
     let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .plain, target: self, action: #selector(buttonPaging(_:)))
     nextBarButtonItem.tag = 1

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -281,8 +281,8 @@ extension TopPageViewController {
 //    let previousBarButtonItem = UIBarButtonItem.roundedIcon(systemName: "arrow.left", iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: previousTag, target: self, action: #selector(buttonPaging(_:)))
 //
 //    // Liquid Glass対応
-//    nextBarButtonItem.applyLiquidGlass()
-//    previousBarButtonItem.applyLiquidGlass()
+//    nextBarButtonItem.adjustLiquidGlass()
+//    previousBarButtonItem.adjustLiquidGlass()
 
     // Liquid Glassのガラス背景を無効化し、見た目を以前のものと同様にする
 

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -152,7 +152,7 @@ extension TopPageViewController {
     let yearTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     yearTextLabel.text = yearText
     yearTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
-    yearTextLabel.textColor = .black
+    yearTextLabel.textColor = .YellowishRed
     yearTextLabel.sizeToFit()
 
     // 日付の表示形式を設定
@@ -163,7 +163,7 @@ extension TopPageViewController {
     let dateTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dateTextLabel.text = dateText
     dateTextLabel.font = UIFont(name: "Thonburi-Bold", size: dateFontSize)
-    dateTextLabel.textColor = .black
+    dateTextLabel.textColor = .YellowishRed
     dateTextLabel.sizeToFit()
 
     // 曜日の表示形式の設定
@@ -174,7 +174,7 @@ extension TopPageViewController {
     let dayOfWeekTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dayOfWeekTextLabel.text = dayOfWeekText
     dayOfWeekTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
-    dayOfWeekTextLabel.textColor = .black
+    dayOfWeekTextLabel.textColor = .YellowishRed
     dayOfWeekTextLabel.sizeToFit()
 
     // AutoLayoutを使用するための設定

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -152,7 +152,7 @@ extension TopPageViewController {
     let yearTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     yearTextLabel.text = yearText
     yearTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
-    yearTextLabel.textColor = .YellowishRed
+    yearTextLabel.textColor = .yellowishRed
     yearTextLabel.sizeToFit()
 
     // 日付の表示形式を設定
@@ -163,7 +163,7 @@ extension TopPageViewController {
     let dateTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dateTextLabel.text = dateText
     dateTextLabel.font = UIFont(name: "Thonburi-Bold", size: dateFontSize)
-    dateTextLabel.textColor = .YellowishRed
+    dateTextLabel.textColor = .yellowishRed
     dateTextLabel.sizeToFit()
 
     // 曜日の表示形式の設定
@@ -174,7 +174,7 @@ extension TopPageViewController {
     let dayOfWeekTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dayOfWeekTextLabel.text = dayOfWeekText
     dayOfWeekTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
-    dayOfWeekTextLabel.textColor = .YellowishRed
+    dayOfWeekTextLabel.textColor = .yellowishRed
     dayOfWeekTextLabel.sizeToFit()
 
     // AutoLayoutを使用するための設定
@@ -240,7 +240,7 @@ extension TopPageViewController {
   private func navigationBarButtonSetting() {
 
     let barIconColor = UIColor.white
-    let backgroundColor = UIColor.YellowishRed
+    let backgroundColor = UIColor.yellowishRed
     let nextTag = 1
     let previousTag = 2
     let nextSystemName = "chevron.forward"

--- a/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
+++ b/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
@@ -13,7 +13,7 @@ extension UIBarButtonItem: LiquidGlassSupporting {
   func adjustLiquidGlass() {
     if #available(iOS 26, *) {
       style = .prominent
-      tintColor = .YellowishRed
+      tintColor = .yellowishRed
     }
   }
 }

--- a/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
+++ b/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
@@ -10,16 +10,10 @@ import UIKit
 
 extension UIBarButtonItem: LiquidGlassSupporting {
 
-  func applyLiquidGlass() {
+  func adjustLiquidGlass() {
     if #available(iOS 26, *) {
       style = .prominent
       tintColor = .YellowishRed
-    }
-  }
-
-  func revertLiquidGlass() {
-    if #available(iOS 26.0, *) {
-      hidesSharedBackground = true
     }
   }
 }

--- a/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
+++ b/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
@@ -12,7 +12,6 @@ extension UIBarButtonItem: LiquidGlassSupporting {
 
   func applyLiquidGlass() {
     if #available(iOS 26, *) {
-      style = .prominent
       tintColor = .YellowishRed
     }
   }

--- a/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
+++ b/Zidosuta/Utilitis/Extensions/LiquidGlassSupporting/UIBarButtonItem+LiquidGlassSupporting.swift
@@ -12,6 +12,7 @@ extension UIBarButtonItem: LiquidGlassSupporting {
 
   func applyLiquidGlass() {
     if #available(iOS 26, *) {
+      style = .prominent
       tintColor = .YellowishRed
     }
   }

--- a/Zidosuta/Utilitis/Extensions/UIBarButtonItem+IconFactory.swift
+++ b/Zidosuta/Utilitis/Extensions/UIBarButtonItem+IconFactory.swift
@@ -1,0 +1,61 @@
+//
+//  UIBarButtonItem+IconFactory.swift
+//  Zidosuta
+//
+//  Created by 川島真之 on 2026/05/28.
+//
+
+import Foundation
+import UIKit
+
+extension UIBarButtonItem {
+
+  // iOS25以前用: 丸背景付きアイコン
+  static func roundedIcon(
+    systemName: String,
+    size: CGFloat = 36,
+    iconColor: UIColor,
+    backgroundColor: UIColor,
+    directionTag: Int? = nil,
+    target: Any?,
+    action: Selector
+  ) -> UIBarButtonItem {
+
+    let button = UIButton(type: .system)
+    let config = UIImage.SymbolConfiguration(pointSize: size * 0.4, weight: .medium)
+    button.setImage(UIImage(systemName: systemName, withConfiguration: config), for: .normal)
+    button.tintColor = iconColor
+    button.frame = CGRect(x: 0, y: 0, width: size, height: size)
+    button.backgroundColor = backgroundColor
+    button.layer.cornerRadius = size / 2
+    button.layer.masksToBounds = true
+    if let directionTag {
+      button.tag = directionTag
+    }
+    button.addTarget(target, action: action, for: .touchUpInside)
+
+    return UIBarButtonItem(customView: button)
+  }
+
+  // iOS26以降用: LiquidGlass付きアイコン
+  @available(iOS 26, *)
+  static func liquidGlassIcon(
+    systemName: String,
+    iconColor: UIColor,
+    directionTag: Int? = nil,
+    target: Any?,
+    action: Selector
+  ) -> UIBarButtonItem {
+
+    let image = UIImage(systemName: systemName)?
+      .withTintColor(iconColor, renderingMode: .alwaysOriginal)
+
+    let item = UIBarButtonItem(image: image, style: .plain, target: target, action: action)
+    if let directionTag {
+      item.tag = directionTag
+    }
+    item.applyLiquidGlass()
+
+    return item
+  }
+}

--- a/Zidosuta/Utilitis/Extensions/UIBarButtonItem+IconFactory.swift
+++ b/Zidosuta/Utilitis/Extensions/UIBarButtonItem+IconFactory.swift
@@ -54,7 +54,7 @@ extension UIBarButtonItem {
     if let directionTag {
       item.tag = directionTag
     }
-    item.applyLiquidGlass()
+    item.adjustLiquidGlass()
 
     return item
   }

--- a/Zidosuta/Utilitis/Extensions/UIButton+AdjustmentOfappearance.swift
+++ b/Zidosuta/Utilitis/Extensions/UIButton+AdjustmentOfappearance.swift
@@ -19,7 +19,7 @@ extension UIButton {
   // アクティブ状態のボタンの外観の設定
   func configureEnabledButtonAppearance() {
 
-    self.tintColor = UIColor.systemBlue
+    self.tintColor = UIColor.customBlue
     self.backgroundColor = nil
     applyFrostedGlassEffect()
   }

--- a/Zidosuta/Utilitis/Extensions/UIButton+AdjustmentOfappearance.swift
+++ b/Zidosuta/Utilitis/Extensions/UIButton+AdjustmentOfappearance.swift
@@ -76,6 +76,10 @@ extension UIButton {
   // ボタンを丸くする
   func setCornerRadius(_ cornerRadius: CGFloat? = nil) {
 
+    if #available(iOS 26.0, *) {
+      self.cornerConfiguration = .capsule()
+    }
+
     let radius = cornerRadius ?? self.frame.size.width / 2
     self.layer.cornerRadius = radius
     self.clipsToBounds = true

--- a/Zidosuta/Utilitis/Extensions/UIColor+AppThemeColor.swift
+++ b/Zidosuta/Utilitis/Extensions/UIColor+AppThemeColor.swift
@@ -19,4 +19,7 @@ extension UIColor {
   class var CornflowerBlue: UIColor {
     return UIColor(named: "CornflowerBlue")!
   }
+  class var customBlue: UIColor {
+    return UIColor(named: "CustomBlue")!
+  }
 }

--- a/Zidosuta/Utilitis/Extensions/UIColor+AppThemeColor.swift
+++ b/Zidosuta/Utilitis/Extensions/UIColor+AppThemeColor.swift
@@ -10,13 +10,13 @@ import UIKit
 
 extension UIColor {
 
-  class var YellowishRed: UIColor {
+  class var yellowishRed: UIColor {
     return UIColor(named: "YellowishRed")!
   }
-  class var OysterWhite: UIColor {
+  class var oysterWhite: UIColor {
     return UIColor(named: "OysterWhite")!
   }
-  class var CornflowerBlue: UIColor {
+  class var cornflowerBlue: UIColor {
     return UIColor(named: "CornflowerBlue")!
   }
   class var customBlue: UIColor {

--- a/Zidosuta/View/Base/LiquidGlassSupporting.swift
+++ b/Zidosuta/View/Base/LiquidGlassSupporting.swift
@@ -10,6 +10,5 @@ import Foundation
 @MainActor
 protocol LiquidGlassSupporting {
 
-  func applyLiquidGlass()
-  func revertLiquidGlass()
+  func adjustLiquidGlass()
 }

--- a/Zidosuta/View/Graph/GraphView.swift
+++ b/Zidosuta/View/Graph/GraphView.swift
@@ -15,7 +15,7 @@ class GraphView: UIView, NibLoadable {
 
   @IBOutlet weak var mainBackgroundView: UIView! {
     didSet {
-      mainBackgroundView.backgroundColor = .OysterWhite
+      mainBackgroundView.backgroundColor = .oysterWhite
     }
   }
 

--- a/Zidosuta/View/OnboardingView/OnboardingView.swift
+++ b/Zidosuta/View/OnboardingView/OnboardingView.swift
@@ -16,7 +16,7 @@ struct OnboardingView: View {
 
     let appearance = UINavigationBarAppearance()
     appearance.configureWithOpaqueBackground()
-    appearance.backgroundColor = UIColor(named: "YellowishRed")
+    appearance.backgroundColor = UIColor(named: "yellowishRed")
     appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
     appearance.buttonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.white]
 
@@ -44,7 +44,7 @@ struct OnboardingView: View {
   var body: some View {
     NavigationView {
       ZStack {
-        Color("YellowishRed")
+        Color("yellowishRed")
           .ignoresSafeArea()
         GeometryReader { geometry in
           VStack(alignment: .center, spacing: 20) {
@@ -81,7 +81,7 @@ struct OnboardingView: View {
                       .padding(.vertical, 10)
                   }
                 )
-                .background(Color("YellowishRed"))
+                .background(Color("yellowishRed"))
                 .cornerRadius(10)
                 .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
               }
@@ -99,7 +99,7 @@ struct OnboardingView: View {
                     .padding(.vertical, 12)
                 }
               )
-              .background(Color("YellowishRed"))
+              .background(Color("yellowishRed"))
               .cornerRadius(10)
               .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
 
@@ -113,7 +113,7 @@ struct OnboardingView: View {
             .frame(width: geometry.size.width - 30, height: geometry.size.height / 2)
             .background(
               Rectangle()
-                .fill(Color("OysterWhite"))
+                .fill(Color("oysterWhite"))
                 .frame(width: geometry.size.width - 40, height: geometry.size.height / 2)
                 .cornerRadius(10)
                 .padding(.top, 10)

--- a/Zidosuta/View/OnboardingView/PhotoTipsView.swift
+++ b/Zidosuta/View/OnboardingView/PhotoTipsView.swift
@@ -22,10 +22,10 @@ struct PhotoTipsView: View {
     NavigationView {
       GeometryReader { outerGeometry in
         ZStack {
-          Color("YellowishRed")
+          Color("yellowishRed")
             .ignoresSafeArea()
           ZStack {
-            Color("OysterWhite")
+            Color("oysterWhite")
             GeometryReader { geometry in
 
               VStack(alignment: .center) {
@@ -102,7 +102,7 @@ struct PhotoTipsView: View {
                       .padding(.horizontal, 50)
                       .padding(.vertical, 15)
                   })
-                  .background(Color("YellowishRed"))
+                  .background(Color("yellowishRed"))
                   .cornerRadius(10)
                   .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
 
@@ -132,7 +132,7 @@ struct PhotoTipsView: View {
 
   // MARK: - Method
 
-  // 外側のYellowishRedの領域の高さの設定
+  // 外側のyellowishRedの領域の高さの設定
   private func calculateVerticalMargin(for screenSize: CGSize) -> CGFloat {
 
     let screenHeight = screenSize.height

--- a/Zidosuta/View/OtherView/DateSelectionView/Cell/ConfirmTableViewCell.swift
+++ b/Zidosuta/View/OtherView/DateSelectionView/Cell/ConfirmTableViewCell.swift
@@ -22,7 +22,7 @@ class ConfirmTableViewCell: UITableViewCell {
     didSet {
       confirmButton.layer.cornerRadius = 8
       confirmButton.layer.masksToBounds = true
-      confirmButton.backgroundColor = .YellowishRed
+      confirmButton.backgroundColor = .yellowishRed
       confirmButton.setTitleColor(.white, for: .normal)
     }
   }

--- a/Zidosuta/View/OtherView/DateSelectionView/Cell/SelectedDateDisplayTableViewCell.swift
+++ b/Zidosuta/View/OtherView/DateSelectionView/Cell/SelectedDateDisplayTableViewCell.swift
@@ -12,7 +12,7 @@ class SelectedDateDisplayTableViewCell: UITableViewCell {
   @IBOutlet weak var shadowLayerView: ShadowLayerView!
   @IBOutlet weak var mainBackgroundView: UIView! {
     didSet {
-      mainBackgroundView.backgroundColor = .OysterWhite
+      mainBackgroundView.backgroundColor = .oysterWhite
     }
   }
 

--- a/Zidosuta/View/Settings/Cell/BaseView/MainBackgroundView.swift
+++ b/Zidosuta/View/Settings/Cell/BaseView/MainBackgroundView.swift
@@ -25,6 +25,6 @@ class MainBackgroundView: UIView {
 
     self.layer.cornerRadius = 8
     self.layer.masksToBounds = true
-    self.backgroundColor = .OysterWhite
+    self.backgroundColor = .oysterWhite
   }
 }

--- a/Zidosuta/View/Settings/Cell/DeleteData/DataDeletionExecutionView/Cell/DeleteAllDataTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/DeleteData/DataDeletionExecutionView/Cell/DeleteAllDataTableViewCell.swift
@@ -24,7 +24,7 @@ class DeleteAllDataTableViewCell: UITableViewCell {
   @IBOutlet weak var shadowLayerView: UIView!
   @IBOutlet weak var mainBackgroundView: UIView! {
     didSet {
-      mainBackgroundView.backgroundColor = .OysterWhite
+      mainBackgroundView.backgroundColor = .oysterWhite
     }
   }
 

--- a/Zidosuta/View/Settings/Cell/DeleteData/DeleteDataTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/DeleteData/DeleteDataTableViewCell.swift
@@ -29,7 +29,7 @@ class DeleteDataTableViewCell: UITableViewCell {
 
   @IBOutlet weak var transitionButton: UIButton! {
     didSet {
-      transitionButton.tintColor = .YellowishRed
+      transitionButton.tintColor = .yellowishRed
     }
   }
 

--- a/Zidosuta/View/Settings/Cell/Notification/NotificationSettingView/Cell/NotificationRegisterTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Notification/NotificationSettingView/Cell/NotificationRegisterTableViewCell.swift
@@ -26,7 +26,7 @@ class NotificationRegisterTableViewCell: UITableViewCell {
     didSet {
       registerButton.layer.cornerRadius = 8
       registerButton.layer.masksToBounds = true
-      registerButton.backgroundColor = .YellowishRed
+      registerButton.backgroundColor = .yellowishRed
       registerButton.setTitleColor(.white, for: .normal)
     }
   }

--- a/Zidosuta/View/Settings/Cell/Notification/NotificationSettingView/Cell/NotificationTimeDisplayTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Notification/NotificationSettingView/Cell/NotificationTimeDisplayTableViewCell.swift
@@ -15,7 +15,7 @@ class NotificationTimeDisplayTableViewCell: UITableViewCell {
   @IBOutlet weak var shadowLayerView: UIView!
   @IBOutlet weak var mainBackgroundView: UIView! {
     didSet {
-      mainBackgroundView.backgroundColor = .OysterWhite
+      mainBackgroundView.backgroundColor = .oysterWhite
     }
   }
   @IBOutlet weak var timeLabel: UILabel!

--- a/Zidosuta/View/Settings/Cell/Notification/NotificationTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Notification/NotificationTableViewCell.swift
@@ -29,7 +29,7 @@ class NotificationTableViewCell: UITableViewCell {
   @IBOutlet weak var notificationSwitch: UISwitch!
   @IBOutlet weak var statusLabel: UILabel! {
     didSet {
-      statusLabel.textColor = .YellowishRed
+      statusLabel.textColor = .yellowishRed
     }
   }
 
@@ -45,7 +45,7 @@ class NotificationTableViewCell: UITableViewCell {
 
     MainActor.assumeIsolated {
       self.contentView.backgroundColor = .systemGray6
-      notificationSwitch.onTintColor = .YellowishRed
+      notificationSwitch.onTintColor = .yellowishRed
       notificationSwitch.tintColor = .lightGray
     }
   }

--- a/Zidosuta/View/Settings/Cell/Terms/PrivacyPolicy/PrivacyPolicyTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Terms/PrivacyPolicy/PrivacyPolicyTableViewCell.swift
@@ -19,7 +19,7 @@ class PrivacyPolicyTableViewCell: UITableViewCell {
   @IBOutlet weak var privacyPolicyLabel: UILabel!
   @IBOutlet weak var transitionButton: UIButton! {
     didSet {
-      transitionButton.tintColor = .YellowishRed
+      transitionButton.tintColor = .yellowishRed
     }
   }
   var delegate: PrivacyPolicyTableViewCellDelegate?

--- a/Zidosuta/View/Settings/Cell/Terms/TermsofUse/TermsOfUseTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Terms/TermsofUse/TermsOfUseTableViewCell.swift
@@ -29,7 +29,7 @@ class TermsOfUseTableViewCell: UITableViewCell {
   @IBOutlet weak var termsOfUseLabel: UILabel!
   @IBOutlet weak var transitionButton: UIButton! {
     didSet {
-      transitionButton.tintColor = .YellowishRed
+      transitionButton.tintColor = .yellowishRed
     }
   }
   var delegate: TermsOfUseTableViewCellDelegate?

--- a/Zidosuta/View/Storyboard/Top.storyboard
+++ b/Zidosuta/View/Storyboard/Top.storyboard
@@ -75,9 +75,7 @@
                         <rect key="frame" x="0.0" y="96" width="414" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
-                        <navigationBarAppearance key="scrollEdgeAppearance">
-                            <color key="backgroundColor" systemColor="systemGray6Color"/>
-                        </navigationBarAppearance>
+                        <navigationBarAppearance key="scrollEdgeAppearance"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -93,9 +91,6 @@
         <image name="house" catalog="system" width="128" height="104"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Zidosuta/View/Top/Cell/AdTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/AdTableViewCell.swift
@@ -15,7 +15,7 @@ class AdTableViewCell: UITableViewCell {
 
   @IBOutlet weak var bannerView: BannerView! {
     didSet {
-      backgroundView?.backgroundColor = .OysterWhite
+      backgroundView?.backgroundColor = .oysterWhite
     }
   }
 

--- a/Zidosuta/View/Top/Cell/MemoTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/MemoTableViewCell.swift
@@ -37,7 +37,7 @@ class MemoTableViewCell: UITableViewCell {
 
     MainActor.assumeIsolated {
 
-      backgroundColor = .OysterWhite
+      backgroundColor = .oysterWhite
 
       memoTextField.keyboardType = .default
       memoTextField.returnKeyType = .done

--- a/Zidosuta/View/Top/Cell/MemoTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/MemoTableViewCell.swift
@@ -36,6 +36,9 @@ class MemoTableViewCell: UITableViewCell {
     // Initialization code
 
     MainActor.assumeIsolated {
+
+      backgroundColor = .OysterWhite
+
       memoTextField.keyboardType = .default
       memoTextField.returnKeyType = .done
       memoTextField.delegate = self

--- a/Zidosuta/View/Top/Cell/PhotoTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/PhotoTableViewCell.swift
@@ -49,6 +49,7 @@ class PhotoTableViewCell: UITableViewCell {
 
     MainActor.assumeIsolated {
 
+      backgroundColor = .OysterWhite
       commentLabel.adjustsFontSizeToFitWidth = true
       commentLabel.minimumScaleFactor = 0.5
 

--- a/Zidosuta/View/Top/Cell/PhotoTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/PhotoTableViewCell.swift
@@ -49,12 +49,12 @@ class PhotoTableViewCell: UITableViewCell {
 
     MainActor.assumeIsolated {
 
-      backgroundColor = .OysterWhite
+      backgroundColor = .oysterWhite
       commentLabel.adjustsFontSizeToFitWidth = true
       commentLabel.minimumScaleFactor = 0.5
-      commentLabel.tintColor = .YellowishRed
+      commentLabel.tintColor = .yellowishRed
 
-      photoImageView.backgroundColor = UIColor.OysterWhite
+      photoImageView.backgroundColor = UIColor.oysterWhite
       // photoImageViewのimageを監視する
       // imageの値が変わるたびにnilが代入されたか否かで分岐して処理を行う
       photoImageView.addObserver(self, forKeyPath: #keyPath(UIImageView.image), options: [.new, .old], context: nil)
@@ -67,7 +67,7 @@ class PhotoTableViewCell: UITableViewCell {
       let radius = insertButton.frame.size.width / 2
       insertButton.layer.cornerRadius = radius
       insertButton.backgroundColor = UIColor.white
-      insertButton.tintColor = .YellowishRed
+      insertButton.tintColor = .yellowishRed
 
       insertButton.layer.shadowColor = UIColor.gray.cgColor  // 影の色
       insertButton.layer.shadowOffset = CGSize(width: 0, height: 1)  // 影のオフセット

--- a/Zidosuta/View/Top/Cell/PhotoTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/PhotoTableViewCell.swift
@@ -52,6 +52,7 @@ class PhotoTableViewCell: UITableViewCell {
       backgroundColor = .OysterWhite
       commentLabel.adjustsFontSizeToFitWidth = true
       commentLabel.minimumScaleFactor = 0.5
+      commentLabel.tintColor = .YellowishRed
 
       photoImageView.backgroundColor = UIColor.OysterWhite
       // photoImageViewのimageを監視する
@@ -66,6 +67,7 @@ class PhotoTableViewCell: UITableViewCell {
       let radius = insertButton.frame.size.width / 2
       insertButton.layer.cornerRadius = radius
       insertButton.backgroundColor = UIColor.white
+      insertButton.tintColor = .YellowishRed
 
       insertButton.layer.shadowColor = UIColor.gray.cgColor  // 影の色
       insertButton.layer.shadowOffset = CGSize(width: 0, height: 1)  // 影のオフセット

--- a/Zidosuta/View/Top/Cell/PhotoTableViewCell.xib
+++ b/Zidosuta/View/Top/Cell/PhotoTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="PhotoTableViewCell" rowHeight="407" id="KGk-i7-Jjw" customClass="PhotoTableViewCell" customModule="DietApp" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="PhotoTableViewCell" rowHeight="407" id="KGk-i7-Jjw" customClass="PhotoTableViewCell" customModule="Zidosuta" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="400"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/Zidosuta/View/Top/Cell/WeightTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/WeightTableViewCell.swift
@@ -60,6 +60,8 @@ class WeightTableViewCell: UITableViewCell {
     // Initialization code
 
     MainActor.assumeIsolated {
+
+      backgroundColor = .OysterWhite
       // キーボードタイプ設定
       weightTextField.keyboardType = .decimalPad
 

--- a/Zidosuta/View/Top/Cell/WeightTableViewCell.swift
+++ b/Zidosuta/View/Top/Cell/WeightTableViewCell.swift
@@ -27,7 +27,7 @@ extension UITextField {
     // heightにはアンダーラインの高さを入れる
     underline.frame = CGRect(x: 0, y: frame.height, width: frame.width, height: 2.0)
     // 枠線の色
-    underline.backgroundColor = UIColor.YellowishRed
+    underline.backgroundColor = UIColor.yellowishRed
     addSubview(underline)
     // 枠線を最前面に
     bringSubviewToFront(underline)
@@ -61,7 +61,7 @@ class WeightTableViewCell: UITableViewCell {
 
     MainActor.assumeIsolated {
 
-      backgroundColor = .OysterWhite
+      backgroundColor = .oysterWhite
       // キーボードタイプ設定
       weightTextField.keyboardType = .decimalPad
 

--- a/Zidosuta/View/Top/TopView.swift
+++ b/Zidosuta/View/Top/TopView.swift
@@ -46,6 +46,6 @@ class TopView: UIView, NibLoadable {
     }
 
     tableView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-    tableView.backgroundColor = .OysterWhite
+    tableView.backgroundColor = .oysterWhite
   }
 }

--- a/Zidosuta/View/Top/TopView.swift
+++ b/Zidosuta/View/Top/TopView.swift
@@ -46,5 +46,6 @@ class TopView: UIView, NibLoadable {
     }
 
     tableView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+    tableView.backgroundColor = .OysterWhite
   }
 }

--- a/Zidosuta/View/Top/TopView.xib
+++ b/Zidosuta/View/Top/TopView.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TopView" customModule="DietApp" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TopView" customModule="Zidosuta" customModuleProvider="target">
             <connections>
                 <outlet property="tableView" destination="Atp-vt-CA8" id="SFU-69-dcr"/>
             </connections>
@@ -19,12 +19,11 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Atp-vt-CA8">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="96" width="414" height="732"/>
                     <inset key="separatorInset" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="Atp-vt-CA8" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="LzS-nk-Z9h"/>
                 <constraint firstItem="Atp-vt-CA8" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="c2q-Ih-gp9"/>
@@ -34,9 +33,4 @@
             <point key="canvasLocation" x="131.8840579710145" y="68.973214285714278"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>


### PR DESCRIPTION
## issue
close #333 
## やったこと
- NavigationBar内のLiquidGlass対応
- NavigationBarの新レイアウト移行作業
- TableViewの新レイアウトへの移行作業
- 他、iOS26でのビルド時のレイアウトの崩れの修正作業

## 作業前後のTop画面
**作業前**
<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-24 at 12 36 31" src="https://github.com/user-attachments/assets/d108b7ce-f9c0-482f-8aa4-8785e7eacb53" />

**作業後**
<img width="603" height="1311" alt="Simulator Screenshot - iPhone17 26 5 - 2026-05-28 at 16 33 28" src="https://github.com/user-attachments/assets/f532a9f6-60e6-48a0-98db-24226c2fe9c9" />

## その他
