### PR TITLE
グラフ画面のLiquidGlass対応と新レイアウトへの移行

### DIFF
--- a/Zidosuta/Controller/Graph/GraphNavigationController.swift
+++ b/Zidosuta/Controller/Graph/GraphNavigationController.swift
@@ -26,14 +26,6 @@ class GraphNavigationController: UINavigationController {
 
     super.viewDidLoad()
     // Do any additional setup after loading the view.
-    let appearance = UINavigationBarAppearance()
-    appearance.configureWithOpaqueBackground()
-    appearance.backgroundColor = UIColor.yellowishRed
-
-    self.navigationBar.standardAppearance = appearance
-    self.navigationBar.scrollEdgeAppearance = appearance
-
-    self.navigationController?.navigationBar.compactAppearance = appearance
   }
 
 

--- a/Zidosuta/Controller/Graph/GraphPageViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphPageViewController.swift
@@ -143,7 +143,7 @@ extension GraphPageViewController {
     let dateTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     dateTextLabel.text = dateText
     dateTextLabel.font = UIFont(name: "Thonburi-Bold", size: dateFontSize)
-    dateTextLabel.textColor = .black
+    dateTextLabel.textColor = .yellowishRed
     dateTextLabel.sizeToFit()
 
     // 年の表示形式の設定
@@ -154,7 +154,7 @@ extension GraphPageViewController {
     let yearTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     yearTextLabel.text = yearText
     yearTextLabel.font = UIFont(name: "Thonburi", size: fontSize)
-    yearTextLabel.textColor = .black
+    yearTextLabel.textColor = .yellowishRed
     yearTextLabel.sizeToFit()
 
     // AutoLayoutを使用するための設定

--- a/Zidosuta/Controller/Graph/GraphPageViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphPageViewController.swift
@@ -123,8 +123,8 @@ extension GraphPageViewController {
 
     var yearText = ""
     var dateText = ""
-    let dateFontSize: CGFloat = 18.0
-    let fontSize: CGFloat = 14.0
+    let dateFontSize: CGFloat = 20.0
+    let fontSize: CGFloat = 16.0
 
     // カスタムビューをインスタンス化
     let customTitleView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: self.navigationController!.navigationBar.frame.size.height))

--- a/Zidosuta/Controller/Graph/GraphPageViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphPageViewController.swift
@@ -185,21 +185,43 @@ extension GraphPageViewController {
   // barButtonの設定
   private func navigationBarButtonSetting() {
 
-    let arrowRight = UIImage(systemName: "arrow.right")?
-        .withTintColor(.white, renderingMode: .alwaysOriginal)
-    let arrowLeft = UIImage(systemName: "arrow.left")?
-        .withTintColor(.white, renderingMode: .alwaysOriginal)
+    let barIconColor = UIColor.white
+    let backgroundColor = UIColor.yellowishRed
+    let nextTag = 1
+    let previousTag = 2
+    let nextSystemName = "chevron.forward"
+    let previousSystemName = "chevron.backward"
 
-    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .done, target: self, action: #selector(buttonPaging(_:)))
-    nextBarButtonItem.tag = 1
-    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .done, target: self, action: #selector(buttonPaging(_:)))
-    previousBarButtonItem.tag = 2
+    if #available(iOS 26, *) {
 
-    nextBarButtonItem.adjustLiquidGlass()
-    previousBarButtonItem.adjustLiquidGlass()
+      let nextBarButtonItem = UIBarButtonItem.liquidGlassIcon(systemName: nextSystemName, iconColor: barIconColor, directionTag: nextTag, target: self, action: #selector(buttonPaging(_:)))
+      let previousBarButtonItem = UIBarButtonItem.liquidGlassIcon(systemName: previousSystemName, iconColor: barIconColor, directionTag: previousTag, target: self, action: #selector(buttonPaging(_:)))
 
-    self.navigationItem.rightBarButtonItem = nextBarButtonItem
-    self.navigationItem.leftBarButtonItem = previousBarButtonItem
+      self.navigationItem.rightBarButtonItem = nextBarButtonItem
+      self.navigationItem.leftBarButtonItem = previousBarButtonItem
+    } else {
+
+      let nextBarButtonItem = UIBarButtonItem.roundedIcon(systemName: nextSystemName, iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: nextTag, target: self, action: #selector(buttonPaging(_:)))
+      let previousBarButtonItem = UIBarButtonItem.roundedIcon(systemName: previousSystemName, iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: previousTag, target: self, action: #selector(buttonPaging(_:)))
+
+      self.navigationItem.rightBarButtonItem = nextBarButtonItem
+      self.navigationItem.leftBarButtonItem = previousBarButtonItem
+    }
+//    let arrowRight = UIImage(systemName: "arrow.right")?
+//        .withTintColor(.white, renderingMode: .alwaysOriginal)
+//    let arrowLeft = UIImage(systemName: "arrow.left")?
+//        .withTintColor(.white, renderingMode: .alwaysOriginal)
+//
+//    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .done, target: self, action: #selector(buttonPaging(_:)))
+//    nextBarButtonItem.tag = 1
+//    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .done, target: self, action: #selector(buttonPaging(_:)))
+//    previousBarButtonItem.tag = 2
+//
+//    nextBarButtonItem.adjustLiquidGlass()
+//    previousBarButtonItem.adjustLiquidGlass()
+//
+//    self.navigationItem.rightBarButtonItem = nextBarButtonItem
+//    self.navigationItem.leftBarButtonItem = previousBarButtonItem
   }
 
   @objc private func buttonPaging(_ sender: UIBarButtonItem) {

--- a/Zidosuta/View/Graph/GraphView.xib
+++ b/Zidosuta/View/Graph/GraphView.xib
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GraphView" customModule="DietApp" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GraphView" customModule="Zidosuta" customModuleProvider="target">
             <connections>
                 <outlet property="graphAreaView" destination="iBf-lh-5cY" id="wrN-n5-L9Q"/>
                 <outlet property="mainBackgroundView" destination="j2F-Y7-UOt" id="DLZ-PB-oAk"/>
@@ -26,21 +25,20 @@
                     <color key="backgroundColor" name="OysterWhite"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iBf-lh-5cY" customClass="LineChartView" customModule="Charts">
-                    <rect key="frame" x="48" y="5" width="800" height="383"/>
+                    <rect key="frame" x="48" y="53" width="800" height="301"/>
                     <color key="backgroundColor" name="OysterWhite"/>
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="j2F-Y7-UOt" secondAttribute="bottom" id="5Rr-L2-JuH"/>
                 <constraint firstItem="iBf-lh-5cY" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="5" id="7GS-nv-Tjd"/>
-                <constraint firstItem="j2F-Y7-UOt" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="A89-ZD-PPg"/>
                 <constraint firstItem="iBf-lh-5cY" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="OmW-v8-VIG"/>
                 <constraint firstItem="j2F-Y7-UOt" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Sqo-gj-8Og"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="iBf-lh-5cY" secondAttribute="trailing" id="bht-Nd-oLl"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="iBf-lh-5cY" secondAttribute="bottom" constant="5" id="ndR-rj-tQi"/>
                 <constraint firstAttribute="trailing" secondItem="j2F-Y7-UOt" secondAttribute="trailing" id="vet-b5-wBd"/>
+                <constraint firstItem="j2F-Y7-UOt" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="wh5-Ic-kK2"/>
             </constraints>
             <point key="canvasLocation" x="139.28571428571428" y="327.536231884058"/>
         </view>
@@ -49,8 +47,5 @@
         <namedColor name="OysterWhite">
             <color red="1" green="0.99199998378753662" blue="0.94900000095367432" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/Zidosuta/View/Storyboard/Graph.storyboard
+++ b/Zidosuta/View/Storyboard/Graph.storyboard
@@ -46,7 +46,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
                         <navigationBarAppearance key="scrollEdgeAppearance">
-                            <color key="backgroundColor" systemColor="tertiarySystemGroupedBackgroundColor"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </navigationBarAppearance>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -63,9 +63,6 @@
         <image name="chart.xyaxis.line" catalog="system" width="128" height="102"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="tertiarySystemGroupedBackgroundColor">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Zidosuta/View/Storyboard/Graph.storyboard
+++ b/Zidosuta/View/Storyboard/Graph.storyboard
@@ -45,9 +45,7 @@
                         <rect key="frame" x="0.0" y="96" width="414" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
-                        <navigationBarAppearance key="scrollEdgeAppearance">
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        </navigationBarAppearance>
+                        <navigationBarAppearance key="scrollEdgeAppearance"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>


### PR DESCRIPTION
## issue
close #336 
## やったこと
- NavitationBarのLiquidGlassへの対応と新レイアウトへの移行
## 作業前後のUI
**作業前**
<img width="1266" height="585" alt="Simulator Screenshot - iPhone 17e - 2026-05-24 at 12 37 16" src="https://github.com/user-attachments/assets/4beda380-9f4a-47cb-ab3c-ca9e1f664ebb" />

**作業後**
<img width="1266" height="585" alt="Simulator Screenshot - iPhone 17e - 2026-05-28 at 20 31 56" src="https://github.com/user-attachments/assets/a3bbe5a9-3cbf-44cf-b7a3-648d08b0d808" />

