### PR TITLE
設定一覧画面のNavigationBarを新レイアウトに移行した

### DIFF
--- a/Zidosuta/Controller/Settings/SettingsNavigationController.swift
+++ b/Zidosuta/Controller/Settings/SettingsNavigationController.swift
@@ -15,14 +15,5 @@ class SettingsNavigationController: UINavigationController {
   override func viewDidLoad() {
 
     super.viewDidLoad()
-
-    navigationBar.tintColor = .white
-    let appearance = UINavigationBarAppearance()
-    appearance.configureWithOpaqueBackground()
-    appearance.backgroundColor = UIColor.yellowishRed
-
-    self.navigationBar.standardAppearance = appearance
-    self.navigationBar.scrollEdgeAppearance = appearance
-    self.navigationController?.navigationBar.compactAppearance = appearance
   }
 }

--- a/Zidosuta/Controller/Settings/SettingsViewController.swift
+++ b/Zidosuta/Controller/Settings/SettingsViewController.swift
@@ -265,7 +265,7 @@ extension SettingsViewController {
     let titleTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 22))
     titleTextLabel.text = titleText
     titleTextLabel.font = UIFont(name: "Thonburi-Bold", size: 18.0)
-    titleTextLabel.textColor = .black
+    titleTextLabel.textColor = .yellowishRed
     titleTextLabel.sizeToFit()
 
     titleTextLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/Zidosuta/View/Storyboard/Settings.storyboard
+++ b/Zidosuta/View/Storyboard/Settings.storyboard
@@ -80,9 +80,7 @@
                         <rect key="frame" x="0.0" y="96" width="414" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
-                        <navigationBarAppearance key="scrollEdgeAppearance">
-                            <color key="backgroundColor" systemColor="systemGray6Color"/>
-                        </navigationBarAppearance>
+                        <navigationBarAppearance key="scrollEdgeAppearance"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -98,9 +96,6 @@
         <image name="gearshape" catalog="system" width="128" height="123"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## issue
close #338 
## やったこと
- NavigationBarの新レイアウト移行
## 作業前後のUI
**作業前**
<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-24 at 12 37 33" src="https://github.com/user-attachments/assets/250506c5-47f6-40d7-91c4-45e0eca15b8d" />

**作業後**
<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-29 at 00 39 35" src="https://github.com/user-attachments/assets/049e9ade-2077-40f8-8d11-6e9303edf237" />
