### PR TITLE
OnboardingViewとPhotoTipsViewで使われていた色が表示されなくなっていたバグを修正

### DIFF
--- a/Zidosuta/View/OnboardingView/OnboardingView.swift
+++ b/Zidosuta/View/OnboardingView/OnboardingView.swift
@@ -16,7 +16,7 @@ struct OnboardingView: View {
 
     let appearance = UINavigationBarAppearance()
     appearance.configureWithOpaqueBackground()
-    appearance.backgroundColor = UIColor(named: "yellowishRed")
+    appearance.backgroundColor = UIColor(named: "YellowishRed")
     appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
     appearance.buttonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.white]
 
@@ -44,7 +44,7 @@ struct OnboardingView: View {
   var body: some View {
     NavigationView {
       ZStack {
-        Color("yellowishRed")
+        Color("YellowishRed")
           .ignoresSafeArea()
         GeometryReader { geometry in
           VStack(alignment: .center, spacing: 20) {
@@ -81,7 +81,7 @@ struct OnboardingView: View {
                       .padding(.vertical, 10)
                   }
                 )
-                .background(Color("yellowishRed"))
+                .background(Color("YellowishRed"))
                 .cornerRadius(10)
                 .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
               }
@@ -99,7 +99,7 @@ struct OnboardingView: View {
                     .padding(.vertical, 12)
                 }
               )
-              .background(Color("yellowishRed"))
+              .background(Color("YellowishRed"))
               .cornerRadius(10)
               .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
 
@@ -113,7 +113,7 @@ struct OnboardingView: View {
             .frame(width: geometry.size.width - 30, height: geometry.size.height / 2)
             .background(
               Rectangle()
-                .fill(Color("oysterWhite"))
+                .fill(Color("OysterWhite"))
                 .frame(width: geometry.size.width - 40, height: geometry.size.height / 2)
                 .cornerRadius(10)
                 .padding(.top, 10)

--- a/Zidosuta/View/OnboardingView/PhotoTipsView.swift
+++ b/Zidosuta/View/OnboardingView/PhotoTipsView.swift
@@ -22,10 +22,10 @@ struct PhotoTipsView: View {
     NavigationView {
       GeometryReader { outerGeometry in
         ZStack {
-          Color("yellowishRed")
+          Color("YellowishRed")
             .ignoresSafeArea()
           ZStack {
-            Color("oysterWhite")
+            Color("OysterWhite")
             GeometryReader { geometry in
 
               VStack(alignment: .center) {
@@ -102,7 +102,7 @@ struct PhotoTipsView: View {
                       .padding(.horizontal, 50)
                       .padding(.vertical, 15)
                   })
-                  .background(Color("yellowishRed"))
+                  .background(Color("YellowishRed"))
                   .cornerRadius(10)
                   .shadow(color: .gray.opacity(0.5), radius: 3, x: 2, y: 2)
 


### PR DESCRIPTION
## issue
close #340 
## やったこと
- OnboardingViewの配色バグを修正
- PhotoTipsViewの配色バグを修正
## 作業前後のUI
**作業前**
<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-29 at 11 35 03" src="https://github.com/user-attachments/assets/cf16f0ea-eac4-483c-88b1-93c96ff9d780" />


<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-29 at 11 35 08" src="https://github.com/user-attachments/assets/c9e13177-c497-4654-a828-28ca9e1c5224" />


**作業後**
<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-29 at 11 43 17" src="https://github.com/user-attachments/assets/2f14fb01-ca18-44e5-9fb5-5c01c965a38a" />
<img width="585" height="1266" alt="Simulator Screenshot - iPhone 17e - 2026-05-29 at 11 43 23" src="https://github.com/user-attachments/assets/cc454306-2ead-4e5f-ac0e-d892c3fb0e4e" />

