### PR TITLE
アプリやSceneのライフサイクルでのいくつかの処理を調整した

### DIFF
--- a/Zidosuta/AppDelegate.swift
+++ b/Zidosuta/AppDelegate.swift
@@ -55,10 +55,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // AdMobの初期化
     MobileAds.shared.start(completionHandler: nil)
 
-    // スプラッシュ画面を1秒表示する
-    let splashScreenDuration: UInt32 = 1
-    sleep(splashScreenDuration)
-
     let config = Realm.Configuration(
       schemaVersion: 1,
       migrationBlock: { migration, oldSchemaVersion in

--- a/Zidosuta/Controller/Graph/GraphPageViewController.swift
+++ b/Zidosuta/Controller/Graph/GraphPageViewController.swift
@@ -207,21 +207,6 @@ extension GraphPageViewController {
       self.navigationItem.rightBarButtonItem = nextBarButtonItem
       self.navigationItem.leftBarButtonItem = previousBarButtonItem
     }
-//    let arrowRight = UIImage(systemName: "arrow.right")?
-//        .withTintColor(.white, renderingMode: .alwaysOriginal)
-//    let arrowLeft = UIImage(systemName: "arrow.left")?
-//        .withTintColor(.white, renderingMode: .alwaysOriginal)
-//
-//    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .done, target: self, action: #selector(buttonPaging(_:)))
-//    nextBarButtonItem.tag = 1
-//    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .done, target: self, action: #selector(buttonPaging(_:)))
-//    previousBarButtonItem.tag = 2
-//
-//    nextBarButtonItem.adjustLiquidGlass()
-//    previousBarButtonItem.adjustLiquidGlass()
-//
-//    self.navigationItem.rightBarButtonItem = nextBarButtonItem
-//    self.navigationItem.leftBarButtonItem = previousBarButtonItem
   }
 
   @objc private func buttonPaging(_ sender: UIBarButtonItem) {

--- a/Zidosuta/Controller/Other/DateSelectionViewController.swift
+++ b/Zidosuta/Controller/Other/DateSelectionViewController.swift
@@ -62,10 +62,6 @@ class DateSelectionViewController: UIViewController {
       dateSelectionView.tableView.dataSource = self
       dateSelectionView.tableView.isScrollEnabled = false
       dateSelectionView.tableView.rowHeight = UITableView.automaticDimension
-
-      // NavigationBarの戻るボタンの色を変更
-//      self.navigationController?.navigationBar.tintColor = UIColor.white
-        // Do any additional setup after loading the view.
     }
 
   override func loadView() {

--- a/Zidosuta/Controller/Top/TopPageViewController.swift
+++ b/Zidosuta/Controller/Top/TopPageViewController.swift
@@ -260,38 +260,6 @@ extension TopPageViewController {
       self.navigationItem.rightBarButtonItem = nextBarButtonItem
       self.navigationItem.leftBarButtonItem = previousBarButtonItem
     }
-
-
-    // arrow.right等の色は、そのままLiquid Glassと組み合わせるとUIBarButtonItem(image:で指定したときに肌色っぽくなる。
-    // なのでSFSymbolの初期化時に白色を明示し、renderingMode: .alwaysOriginalでオリジナルのままのレンダリングを指定する
-//    let arrowRight = UIImage(systemName: "arrow.right")?
-//        .withTintColor(barIconColor, renderingMode: .alwaysOriginal)
-//    let arrowLeft = UIImage(systemName: "arrow.left")?
-//        .withTintColor(barIconColor
-//                       , renderingMode: .alwaysOriginal)
-//
-//    let nextBarButtonItem = UIBarButtonItem(image: arrowRight, style: .plain, target: self, action: #selector(buttonPaging(_:)))
-//    nextBarButtonItem.tag = 1
-//    let previousBarButtonItem = UIBarButtonItem(image: arrowLeft, style: .plain, target: self, action: #selector(buttonPaging(_:)))
-//    previousBarButtonItem.tag = 2
-
-//    let nextBarButtonItem = UIBarButtonItem.roundedIcon(systemName: "arrow.right", iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: nextTag, target: self, action: #selector(buttonPaging(_:)))
-//
-//    let previousBarButtonItem = UIBarButtonItem.roundedIcon(systemName: "arrow.left", iconColor: barIconColor, backgroundColor: backgroundColor, directionTag: previousTag, target: self, action: #selector(buttonPaging(_:)))
-//
-//    // Liquid Glass対応
-//    nextBarButtonItem.adjustLiquidGlass()
-//    previousBarButtonItem.adjustLiquidGlass()
-
-    // Liquid Glassのガラス背景を無効化し、見た目を以前のものと同様にする
-
-//    if #available(iOS 26.0, *) {
-//      nextBarButtonItem.hidesSharedBackground = true
-//      previousBarButtonItem.hidesSharedBackground = true
-//    }
-
-//    self.navigationItem.rightBarButtonItem = nextBarButtonItem
-//    self.navigationItem.leftBarButtonItem = previousBarButtonItem
   }
   // BarButton押下時の画面遷移
   @objc func buttonPaging(_ sender: UIBarButtonItem) {

--- a/Zidosuta/SceneDelegate.swift
+++ b/Zidosuta/SceneDelegate.swift
@@ -21,6 +21,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
     routeToAppropriateScreen(scene)
+
+    if connectionOptions.notificationResponse != nil {
+
+      DispatchQueue.main.async {
+        LocalNotificationManager.shared.navigateToTopScreen()
+      }
+    }
   }
 
   func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
## issue
#345 
## やったこと
- アプリがコールド状態の時からローカル通知を受け取った時に、その通知をタップしてもトップ画面に遷移されない問題を修正
- ランチスクリーンの表示時間を１秒固定からシステムに決めさせる方式に変更した

## やっていないこと
- AppDelegate内の処理をSceneDelegateへ移行させる作業
AppDelegateとSceneDelegateを確認したところ、すでに責務の分離ができていた。おそらくこのままでもiOS27の破壊的変更にも対応できると予想したの一旦現状で様子を見ることにした。
