### PR TITLE
iOS26（LiquidGlass）対応のためのUI調整作業　その2

### DIFF
--- a/Zidosuta/AppDelegate.swift
+++ b/Zidosuta/AppDelegate.swift
@@ -42,6 +42,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return .portrait
   }
 
+  // iOS26未満の場合のNavigationBarの戻るボタンの見た目を設定する処理
+  func configureNavigationBarBackButtonAppearanceForPreIOS26() {
+    guard #unavailable(iOS 26.0) else { return }
+
+    let appearance = UINavigationBarAppearance()
+    appearance.buttonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.black]
+
+    let backIndicatorImage = UIImage(systemName: "chevron.backward")?
+      .withTintColor(.black, renderingMode: .alwaysOriginal)
+    appearance.setBackIndicatorImage(backIndicatorImage, transitionMaskImage: backIndicatorImage)
+
+    UINavigationBar.appearance().standardAppearance = appearance
+    UINavigationBar.appearance().scrollEdgeAppearance = appearance
+    UINavigationBar.appearance().compactAppearance = appearance
+  }
+
 
   // MARK: - LifeCycle
 
@@ -67,6 +83,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     UNUserNotificationCenter.current().delegate = self
     // 通知機能がオンなら保存された通知設定を復元
     LocalNotificationManager.shared.restoreNotificationIfNeeded()
+
+    configureNavigationBarBackButtonAppearanceForPreIOS26()
 
     return true
   }

--- a/Zidosuta/AppDelegate.swift
+++ b/Zidosuta/AppDelegate.swift
@@ -103,6 +103,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 
+// MARK: - UNUserNotificationCenterDelegate
+
 extension AppDelegate: @MainActor UNUserNotificationCenterDelegate {
 
   // ユーザーが通知に対してアクションをとった時に呼ばれるデリゲートメソッド

--- a/Zidosuta/View/OnboardingView/OnboardingView.swift
+++ b/Zidosuta/View/OnboardingView/OnboardingView.swift
@@ -12,6 +12,21 @@ struct OnboardingView: View {
 
   // MARK: - Init
 
+//  init() {
+//    if #available(iOS 26.0, *) {
+//    } else {
+//      let appearance = UINavigationBarAppearance()
+//      appearance.buttonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.black]
+//
+//      let backIndicatorImage = UIImage(systemName: "chevron.backward")?
+//        .withTintColor(.black, renderingMode: .alwaysOriginal)
+//      appearance.setBackIndicatorImage(backIndicatorImage, transitionMaskImage: backIndicatorImage)
+//
+//      UINavigationBar.appearance().standardAppearance = appearance
+//      UINavigationBar.appearance().scrollEdgeAppearance = appearance
+//      UINavigationBar.appearance().compactAppearance = appearance
+//    }
+//  }
 
   // MARK: - Properties
 

--- a/Zidosuta/View/Top/PhotoModalView.xib
+++ b/Zidosuta/View/Top/PhotoModalView.xib
@@ -37,7 +37,7 @@
                                 <constraint firstAttribute="width" constant="44" id="ObK-1O-oFz"/>
                             </constraints>
                             <state key="normal" title="Button" backgroundImage="xmark" catalog="system"/>
-                            <buttonConfiguration key="configuration" style="plain" image="chevron.backward" catalog="system"/>
+                            <buttonConfiguration key="configuration" style="plain" image="xmark" catalog="system"/>
                             <connections>
                                 <action selector="dismissButtonAction:" destination="-1" eventType="touchUpInside" id="fd6-hM-n6b"/>
                             </connections>
@@ -68,7 +68,6 @@
         </view>
     </objects>
     <resources>
-        <image name="chevron.backward" catalog="system" width="97" height="128"/>
         <image name="xmark" catalog="system" width="128" height="113"/>
     </resources>
 </document>


### PR DESCRIPTION
## issue
issue #342 
## やったこと
- 写真拡大画面の閉じるボタンのボタンのアイコン変更
- iOS26未満の場合のNavigationBarの戻るボタンの見た目を設定する処理を実装

