### PR TITLE
更新情報表示画面にTableViewとCellを表示できるようにした

### DIFF
--- a/Zidosuta.xcodeproj/project.pbxproj
+++ b/Zidosuta.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		FACA1A542D2BE5EB00B2768D /* TermsTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACA1A532D2BE5EB00B2768D /* TermsTextView.swift */; };
 		FAD64E782FE0FA9A0081D564 /* UpdatesDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD64E772FE0FA9A0081D564 /* UpdatesDisplayView.swift */; };
 		FAD64E7A2FE0FAB40081D564 /* UpdatesDisplayView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */; };
+		FAD64E7D2FE100050081D564 /* UpdatesDisplayTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD64E7B2FE100050081D564 /* UpdatesDisplayTableViewCell.swift */; };
+		FAD64E7E2FE100050081D564 /* UpdatesDisplayTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD64E7C2FE100050081D564 /* UpdatesDisplayTableViewCell.xib */; };
 		FAD9B7D22FDED82600F49466 /* UpdatesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */; };
 		FAD9B7D32FDED82600F49466 /* UpdatesTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */; };
 		FAD9B7D52FDEE49A00F49466 /* UpdatesDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */; };
@@ -334,6 +336,8 @@
 		FACA1A532D2BE5EB00B2768D /* TermsTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsTextView.swift; sourceTree = "<group>"; };
 		FAD64E772FE0FA9A0081D564 /* UpdatesDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayView.swift; sourceTree = "<group>"; };
 		FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesDisplayView.xib; sourceTree = "<group>"; };
+		FAD64E7B2FE100050081D564 /* UpdatesDisplayTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayTableViewCell.swift; sourceTree = "<group>"; };
+		FAD64E7C2FE100050081D564 /* UpdatesDisplayTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesDisplayTableViewCell.xib; sourceTree = "<group>"; };
 		FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesTableViewCell.swift; sourceTree = "<group>"; };
 		FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesTableViewCell.xib; sourceTree = "<group>"; };
 		FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayViewController.swift; sourceTree = "<group>"; };
@@ -977,8 +981,18 @@
 			children = (
 				FAD64E772FE0FA9A0081D564 /* UpdatesDisplayView.swift */,
 				FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */,
+				FAD64E7F2FE100140081D564 /* UpdatesDisplayTableViewCell */,
 			);
 			path = UpdatesDisplayView;
+			sourceTree = "<group>";
+		};
+		FAD64E7F2FE100140081D564 /* UpdatesDisplayTableViewCell */ = {
+			isa = PBXGroup;
+			children = (
+				FAD64E7B2FE100050081D564 /* UpdatesDisplayTableViewCell.swift */,
+				FAD64E7C2FE100050081D564 /* UpdatesDisplayTableViewCell.xib */,
+			);
+			path = UpdatesDisplayTableViewCell;
 			sourceTree = "<group>";
 		};
 		FAD9B7CF2FDED78C00F49466 /* Updates */ = {
@@ -1159,6 +1173,7 @@
 				FA87003F2F7975E00067EAD5 /* Tab.storyboard in Resources */,
 				FA8700402F7975E00067EAD5 /* Top.storyboard in Resources */,
 				FA1187A32A22F652004577F8 /* AdTableViewCell.xib in Resources */,
+				FAD64E7E2FE100050081D564 /* UpdatesDisplayTableViewCell.xib in Resources */,
 				FAD9B7D32FDED82600F49466 /* UpdatesTableViewCell.xib in Resources */,
 				FA32F4C52A32BFCF0058FD32 /* NotificationTableViewCell.xib in Resources */,
 				FA8069182EE6862E0013CBB3 /* SelectedDateDisplayTableViewCell.xib in Resources */,
@@ -1435,6 +1450,7 @@
 				FAC9EF4B2D0E498E00DE1E64 /* DataDeleteManager.swift in Sources */,
 				FA22110D2CFF16D6005C622D /* MainBackgroundView.swift in Sources */,
 				FAC9EF312D0C11E900DE1E64 /* GraphDateManager.swift in Sources */,
+				FAD64E7D2FE100050081D564 /* UpdatesDisplayTableViewCell.swift in Sources */,
 				FA42FA522A81D8CC00C60F9E /* CustomMarkerView.swift in Sources */,
 				FAFF6F602A21C60F0092A1A3 /* MemoTableViewCell.swift in Sources */,
 				FA32F4B82A32BD130058FD32 /* SettingsView.swift in Sources */,

--- a/Zidosuta.xcodeproj/project.pbxproj
+++ b/Zidosuta.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		FACA1A482D255ECD00B2768D /* LocalNotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACA1A472D255ECD00B2768D /* LocalNotificationManagerTests.swift */; };
 		FACA1A522D2A4E2600B2768D /* TermsDisplayViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACA1A512D2A4E2600B2768D /* TermsDisplayViewControllerWrapper.swift */; };
 		FACA1A542D2BE5EB00B2768D /* TermsTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACA1A532D2BE5EB00B2768D /* TermsTextView.swift */; };
+		FAD64E782FE0FA9A0081D564 /* UpdatesDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD64E772FE0FA9A0081D564 /* UpdatesDisplayView.swift */; };
+		FAD64E7A2FE0FAB40081D564 /* UpdatesDisplayView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */; };
 		FAD9B7D22FDED82600F49466 /* UpdatesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */; };
 		FAD9B7D32FDED82600F49466 /* UpdatesTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */; };
 		FAD9B7D52FDEE49A00F49466 /* UpdatesDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */; };
@@ -330,6 +332,8 @@
 		FACA1A472D255ECD00B2768D /* LocalNotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationManagerTests.swift; sourceTree = "<group>"; };
 		FACA1A512D2A4E2600B2768D /* TermsDisplayViewControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsDisplayViewControllerWrapper.swift; sourceTree = "<group>"; };
 		FACA1A532D2BE5EB00B2768D /* TermsTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsTextView.swift; sourceTree = "<group>"; };
+		FAD64E772FE0FA9A0081D564 /* UpdatesDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayView.swift; sourceTree = "<group>"; };
+		FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesDisplayView.xib; sourceTree = "<group>"; };
 		FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesTableViewCell.swift; sourceTree = "<group>"; };
 		FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesTableViewCell.xib; sourceTree = "<group>"; };
 		FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayViewController.swift; sourceTree = "<group>"; };
@@ -968,11 +972,21 @@
 			path = UIViewControllerRepresentable;
 			sourceTree = "<group>";
 		};
+		FAD64E762FE0F9C50081D564 /* UpdatesDisplayView */ = {
+			isa = PBXGroup;
+			children = (
+				FAD64E772FE0FA9A0081D564 /* UpdatesDisplayView.swift */,
+				FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */,
+			);
+			path = UpdatesDisplayView;
+			sourceTree = "<group>";
+		};
 		FAD9B7CF2FDED78C00F49466 /* Updates */ = {
 			isa = PBXGroup;
 			children = (
 				FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */,
 				FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */,
+				FAD64E762FE0F9C50081D564 /* UpdatesDisplayView */,
 			);
 			path = Updates;
 			sourceTree = "<group>";
@@ -1141,6 +1155,7 @@
 				FA87003C2F7975E00067EAD5 /* Graph.storyboard in Resources */,
 				FA87003D2F7975E00067EAD5 /* LaunchScreen.storyboard in Resources */,
 				FA87003E2F7975E00067EAD5 /* Settings.storyboard in Resources */,
+				FAD64E7A2FE0FAB40081D564 /* UpdatesDisplayView.xib in Resources */,
 				FA87003F2F7975E00067EAD5 /* Tab.storyboard in Resources */,
 				FA8700402F7975E00067EAD5 /* Top.storyboard in Resources */,
 				FA1187A32A22F652004577F8 /* AdTableViewCell.xib in Resources */,
@@ -1428,6 +1443,7 @@
 				FA9F9CED2CF5A8540013886A /* TransitionDirection.swift in Sources */,
 				FA0572E92FDFB4B000486AD7 /* HTTPMethod.swift in Sources */,
 				FAA9E7332FA4EA2A00CBED1E /* SettingsCellString.swift in Sources */,
+				FAD64E782FE0FA9A0081D564 /* UpdatesDisplayView.swift in Sources */,
 				FA9E8C402D14641C00A05E55 /* TermsDisplayView.swift in Sources */,
 				FA4D29A32A64F93900C2C5E6 /* GraphContentCreator.swift in Sources */,
 				FA8700472F7A2D190067EAD5 /* ValidationResult.swift in Sources */,

--- a/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
+++ b/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
@@ -9,6 +9,20 @@ import UIKit
 
 class UpdatesDisplayViewController: UIViewController {
 
+
+  // MARK: - Properties
+
+  let updateDisplayView = UpdatesDisplayView()
+
+
+  // MARK: - LifeCycle
+
+  override func loadView() {
+
+    super.loadView()
+    view = updateDisplayView
+  }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
+++ b/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
@@ -7,13 +7,28 @@
 
 import UIKit
 
+struct UpdateItem: Hashable {
+
+  let id: UUID
+  let version: String
+  let description: String
+  let releaseDate: String
+}
+
 class UpdatesDisplayViewController: UIViewController {
 
 
   // MARK: - Properties
 
   let updateDisplayView = UpdatesDisplayView()
+  private var dataSource: UITableViewDiffableDataSource<Section, UpdateItem>!
 
+
+  // MARK: - Enums
+
+  private enum Section {
+    case main
+  }
 
   // MARK: - LifeCycle
 
@@ -23,11 +38,14 @@ class UpdatesDisplayViewController: UIViewController {
     view = updateDisplayView
   }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+  override func viewDidLoad() {
+    super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
-    }
+    // Do any additional setup after loading the view.
+
+    configureDataSource()
+    applyData()
+  }
 
 
     /*
@@ -40,4 +58,40 @@ class UpdatesDisplayViewController: UIViewController {
     }
     */
 
+}
+
+
+// MARK: - UITableViewDiffableDataSource周りの処理
+
+extension UpdatesDisplayViewController {
+
+  private func configureDataSource() {
+
+    dataSource = UITableViewDiffableDataSource<Section, UpdateItem>(tableView: updateDisplayView.tableView, cellProvider: { tableView, indexPath, itemIdentifier in
+
+      let cell = tableView.dequeueReusableCell(withIdentifier: self.updateDisplayView.cellIdentifier, for: indexPath) as! UpdatesDisplayTableViewCell
+
+      cell.versionLabel.text = itemIdentifier.version
+      cell.releaseDateLabel.text = itemIdentifier.releaseDate
+      cell.descriptionLabel.text = itemIdentifier.description
+      return cell
+    })
+  }
+
+  private func applyData() {
+
+    // テスト表示用データ
+    let testData = UpdateItem(id: UUID(), version: "0.0.0", description: "テストテストテストテスト", releaseDate: "2025-02-11")
+    let testData2 = UpdateItem(id: UUID(), version: "0.0.0", description: "テストテストテストテスト", releaseDate: "2025-02-11")
+    let testData3 = UpdateItem(id: UUID(), version: "0.0.0", description: "テストテストテストテスト", releaseDate: "2025-02-11")
+    let testData4 = UpdateItem(id: UUID(), version: "0.0.0", description: "テストテストテストテスト", releaseDate: "2025-02-11")
+    let testData5 = UpdateItem(id: UUID(), version: "0.0.0", description: "テストテストテストテスト", releaseDate: "2025-02-11")
+    let testData6 = UpdateItem(id: UUID(), version: "0.0.0", description: "テストテストテストテスト", releaseDate: "2025-02-11")
+    let testData7 = UpdateItem(id: UUID(), version: "0.0.0", description: "テストテストテストテスト", releaseDate: "2025-02-11")
+
+    var snapshot = NSDiffableDataSourceSnapshot<Section, UpdateItem>()
+    snapshot.appendSections([.main])
+    snapshot.appendItems([testData, testData2, testData3, testData4, testData5, testData6, testData7], toSection: .main)
+    dataSource.apply(snapshot, animatingDifferences: false)
+  }
 }

--- a/Zidosuta/Model/Logic/API/Base/APIClientError.swift
+++ b/Zidosuta/Model/Logic/API/Base/APIClientError.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum APIClientError: Error {
+  
   case invalidURL
   case encodingError(Error)
   case decodingError(Error)

--- a/Zidosuta/Model/Logic/API/Base/APIClientError.swift
+++ b/Zidosuta/Model/Logic/API/Base/APIClientError.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum APIClientError: Error {
-  
+
   case invalidURL
   case encodingError(Error)
   case decodingError(Error)

--- a/Zidosuta/Model/Logic/API/Base/HTTPMethod.swift
+++ b/Zidosuta/Model/Logic/API/Base/HTTPMethod.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum HTTPMethod: String {
+  
   case get = "GET"
   case post = "POST"
   case put = "PUT"

--- a/Zidosuta/Model/Logic/API/Base/HTTPMethod.swift
+++ b/Zidosuta/Model/Logic/API/Base/HTTPMethod.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum HTTPMethod: String {
-  
+
   case get = "GET"
   case post = "POST"
   case put = "PUT"

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.swift
@@ -9,7 +9,16 @@ import UIKit
 
 class UpdatesDisplayTableViewCell: UITableViewCell {
 
-    override func awakeFromNib() {
+
+  // MARK: - Properties
+
+  @IBOutlet weak var versionLabel: UILabel!
+  @IBOutlet weak var releaseDateLabel: UILabel!
+  @IBOutlet weak var descriptionLabel: UILabel!
+  
+// MARK: - LifeCycle
+
+  override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
     }
@@ -19,5 +28,5 @@ class UpdatesDisplayTableViewCell: UITableViewCell {
 
         // Configure the view for the selected state
     }
-    
+
 }

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.swift
@@ -15,7 +15,7 @@ class UpdatesDisplayTableViewCell: UITableViewCell {
   @IBOutlet weak var versionLabel: UILabel!
   @IBOutlet weak var releaseDateLabel: UILabel!
   @IBOutlet weak var descriptionLabel: UILabel!
-  
+
 // MARK: - LifeCycle
 
   override func awakeFromNib() {

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.swift
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  UpdatesDisplayTableViewCell.swift
+//  Zidosuta
+//
+//  Created by 川島真之 on 2026/06/16.
+//
+
+import UIKit
+
+class UpdatesDisplayTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+}

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.xib
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.xib
@@ -47,6 +47,11 @@
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="descriptionLabel" destination="b8a-z8-N3Y" id="ymC-lI-Mb3"/>
+                <outlet property="releaseDateLabel" destination="6bP-Dl-KtM" id="f8u-Zh-f9z"/>
+                <outlet property="versionLabel" destination="7Ny-Ca-RyY" id="WCC-58-nMi"/>
+            </connections>
             <point key="canvasLocation" x="133" y="154"/>
         </tableViewCell>
     </objects>

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.xib
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayTableViewCell/UpdatesDisplayTableViewCell.xib
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="UpdatesDisplayTableViewCell" customModule="Zidosuta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Ny-Ca-RyY">
+                        <rect key="frame" x="8" y="8" width="55" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="XXXX/XX/XX" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6bP-Dl-KtM">
+                        <rect key="frame" x="71" y="13" width="78" height="16"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b8a-z8-N3Y">
+                        <rect key="frame" x="177" y="20" width="86" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="b8a-z8-N3Y" secondAttribute="bottom" constant="19" id="1xo-cF-Slq"/>
+                    <constraint firstItem="b8a-z8-N3Y" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" symbolic="YES" id="7Qe-pe-Tp7"/>
+                    <constraint firstItem="7Ny-Ca-RyY" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="Ddg-uS-0bq"/>
+                    <constraint firstItem="6bP-Dl-KtM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="13" id="fi8-4A-CVb"/>
+                    <constraint firstItem="7Ny-Ca-RyY" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="iaV-nb-0je"/>
+                    <constraint firstItem="6bP-Dl-KtM" firstAttribute="leading" secondItem="7Ny-Ca-RyY" secondAttribute="trailing" constant="8" symbolic="YES" id="mfP-iR-xve"/>
+                    <constraint firstAttribute="trailing" secondItem="b8a-z8-N3Y" secondAttribute="trailing" constant="57" id="tnN-Zp-nhv"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="133" y="154"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
@@ -12,8 +12,13 @@ class UpdatesDisplayView: UIView, NibLoadable {
 
   // MARK: - Properties
 
-  @IBOutlet weak var tableView: UITableView!
-  private let cellIdentifier = "UpdatesDisplayTableViewCell"
+  @IBOutlet weak var tableView: UITableView! {
+    didSet {
+      tableViewSetting()
+    }
+  }
+
+  let cellIdentifier = "UpdatesDisplayTableViewCell"
 
 
     // MARK: - Init

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
@@ -1,0 +1,33 @@
+//
+//  UpdatesDisplayView.swift
+//  Zidosuta
+//
+//  Created by 川島真之 on 2026/06/16.
+//
+
+import UIKit
+
+class UpdatesDisplayView: UIView, NibLoadable {
+
+
+  // MARK: - Properties
+
+  @IBOutlet weak var tableView: UITableView!
+
+  private let cellIdentifier = "Update"
+
+
+    // MARK: - Init
+
+  override init(frame: CGRect) {
+    
+    super.init(frame: frame)
+    nibInit()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+
+    super.init(coder: aDecoder)
+    nibInit()
+  }
+}

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
@@ -19,7 +19,7 @@ class UpdatesDisplayView: UIView, NibLoadable {
     // MARK: - Init
 
   override init(frame: CGRect) {
-    
+
     super.init(frame: frame)
     nibInit()
   }

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.swift
@@ -13,8 +13,7 @@ class UpdatesDisplayView: UIView, NibLoadable {
   // MARK: - Properties
 
   @IBOutlet weak var tableView: UITableView!
-
-  private let cellIdentifier = "Update"
+  private let cellIdentifier = "UpdatesDisplayTableViewCell"
 
 
     // MARK: - Init
@@ -29,5 +28,16 @@ class UpdatesDisplayView: UIView, NibLoadable {
 
     super.init(coder: aDecoder)
     nibInit()
+  }
+
+
+  // MARK: - Methods
+
+  private func tableViewSetting() {
+
+    let nib = UINib(nibName: cellIdentifier, bundle: nil)
+    tableView.register(nib, forCellReuseIdentifier: cellIdentifier)
+
+    // 他TableViewのUI調整
   }
 }

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.xib
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.xib
@@ -21,7 +21,7 @@
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="kYc-dm-Bne">
                     <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="backgroundColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.xib
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.xib
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UpdatesDisplayView" customModule="Zidosuta" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="kYc-dm-Bne" id="mX6-oS-x4W"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="kYc-dm-Bne">
+                    <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="kYc-dm-Bne" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="3b5-Sx-UZh"/>
+                <constraint firstAttribute="bottom" secondItem="kYc-dm-Bne" secondAttribute="bottom" id="7sr-Io-gz8"/>
+                <constraint firstItem="kYc-dm-Bne" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="NCQ-cC-tSO"/>
+                <constraint firstItem="kYc-dm-Bne" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="jyw-Sd-24K"/>
+            </constraints>
+            <point key="canvasLocation" x="138.1679389312977" y="153.52112676056339"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.xib
+++ b/Zidosuta/View/Settings/Cell/Updates/UpdatesDisplayView/UpdatesDisplayView.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +22,7 @@
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="kYc-dm-Bne">
                     <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
-                    <color key="backgroundColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" name="CustomLightGray"/>
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
@@ -36,6 +37,9 @@
         </view>
     </objects>
     <resources>
+        <namedColor name="CustomLightGray">
+            <color red="0.92900002002716064" green="0.92900002002716064" blue="0.92900002002716064" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
## issue
close #356 
## やったこと
- 更新情報表示画面にTableViewを表示できるようにした
- そのTableViewにデモデータが表示されているセルが表示されるようにした。

## UpdatesDisplayViewControllerの仮UI
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-16 at 14 59 47" src="https://github.com/user-attachments/assets/b0f07e97-6190-4438-839f-37c57100c0f3" />
