### PR TITLE
更新情報のキャッシュ周りの処理を作成、実装した

### DIFF
--- a/Zidosuta.xcodeproj/project.pbxproj
+++ b/Zidosuta.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		FAD64E7A2FE0FAB40081D564 /* UpdatesDisplayView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */; };
 		FAD64E7D2FE100050081D564 /* UpdatesDisplayTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD64E7B2FE100050081D564 /* UpdatesDisplayTableViewCell.swift */; };
 		FAD64E7E2FE100050081D564 /* UpdatesDisplayTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD64E7C2FE100050081D564 /* UpdatesDisplayTableViewCell.xib */; };
+		FAD88E722FE4EFF0006B6667 /* UpdatesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD88E712FE4EFF0006B6667 /* UpdatesCache.swift */; };
 		FAD9B7D22FDED82600F49466 /* UpdatesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */; };
 		FAD9B7D32FDED82600F49466 /* UpdatesTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */; };
 		FAD9B7D52FDEE49A00F49466 /* UpdatesDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */; };
@@ -338,6 +339,7 @@
 		FAD64E792FE0FAB40081D564 /* UpdatesDisplayView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesDisplayView.xib; sourceTree = "<group>"; };
 		FAD64E7B2FE100050081D564 /* UpdatesDisplayTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayTableViewCell.swift; sourceTree = "<group>"; };
 		FAD64E7C2FE100050081D564 /* UpdatesDisplayTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesDisplayTableViewCell.xib; sourceTree = "<group>"; };
+		FAD88E712FE4EFF0006B6667 /* UpdatesCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesCache.swift; sourceTree = "<group>"; };
 		FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesTableViewCell.swift; sourceTree = "<group>"; };
 		FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesTableViewCell.xib; sourceTree = "<group>"; };
 		FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayViewController.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 				FA0572FD2FDFF7D000486AD7 /* ZidosutaUpdatesRequest.swift */,
 				FA0573012FDFFBD600486AD7 /* ZidosutaUpdate.swift */,
 				FA0573032FDFFC4600486AD7 /* ZidosutaUpdatesResponse.swift */,
+				FAD88E712FE4EFF0006B6667 /* UpdatesCache.swift */,
 			);
 			path = ZidosutaUpdates;
 			sourceTree = "<group>";
@@ -1411,6 +1414,7 @@
 				FA2211172CFF5E1B005C622D /* NotificationTimeDisplayTableViewCell.swift in Sources */,
 				FA42FA482A7F2F6500C60F9E /* MonthAdjuster.swift in Sources */,
 				FA0573022FDFFBD600486AD7 /* ZidosutaUpdate.swift in Sources */,
+				FAD88E722FE4EFF0006B6667 /* UpdatesCache.swift in Sources */,
 				FA0573082FDFFE8400486AD7 /* EmptyBody.swift in Sources */,
 				FAC9EF182D0C0B5C00DE1E64 /* TopViewController.swift in Sources */,
 				FAC9EF192D0C0B5C00DE1E64 /* GraphViewController.swift in Sources */,

--- a/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
+++ b/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
@@ -59,22 +59,53 @@ class UpdatesDisplayViewController: UIViewController {
       indicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
     ])
 
-    indicator.startAnimating()
+    if UpdatesCache.needsRefresh() {
 
-    Task {
-      do {
-        let result = try await getUpdates()
+      // FIXME: - 更新情報の取得処理がDRYに違反しているため、エラーハンドリング実装後に共通化する
+
+      // キャッシュが存在しない等で更新情報の取得が必要な場合
+      indicator.startAnimating()
+
+      Task {
+        do {
+          let result = try await getUpdates()
+          UpdatesCache.save(result)
+          configureDataSource()
+          applyData(data: result.updates)
+
+          indicator.stopAnimating()
+        } catch {
+          // エラーハンドリング
+          print("エラー発生")
+          indicator.stopAnimating()
+        }
+      }
+    } else {
+      // キャッシュがあった場合の処理
+      if let cache = UpdatesCache.load() {
+        print("有効なキャッシュが存在しました")
         configureDataSource()
-        applyData(data: result.updates)
+        applyData(data: cache.updates)
+      } else {
+        // キャッシュが取得できなかったため再取得
+        print("キャッシュの取得エラー")
 
-        indicator.stopAnimating()
-      } catch {
-        // エラーハンドリング
-        print("エラー発生")
-        indicator.stopAnimating()
+        Task {
+          do {
+            let result = try await getUpdates()
+            UpdatesCache.save(result)
+            configureDataSource()
+            applyData(data: result.updates)
+
+            indicator.stopAnimating()
+          } catch {
+            // エラーハンドリング
+            print("エラー発生")
+            indicator.stopAnimating()
+          }
+        }
       }
     }
-
   }
 
 

--- a/Zidosuta/Model/Logic/API/ZidosutaUpdates/UpdatesCache.swift
+++ b/Zidosuta/Model/Logic/API/ZidosutaUpdates/UpdatesCache.swift
@@ -1,0 +1,42 @@
+//
+//  UpdatesCache.swift
+//  Zidosuta
+//
+//  Created by 川島真之 on 2026/06/19.
+//
+
+import Foundation
+
+enum UpdateInfoCache {
+    private static let key = "cachedUpdates"
+
+    // 現在のアプリバージョン（Info.plist の CFBundleShortVersionString）。
+    // static let なので一度だけ初期化される不変の定数。
+    static let currentAppVersion: String =
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+
+    // キャッシュ読み込み。なければ nil。
+    static func load() -> ZidosutaUpdatesResponse? {
+
+        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(ZidosutaUpdatesResponse.self, from: data)
+    }
+
+    // キャッシュ保存。
+    static func save(_ response: ZidosutaUpdatesResponse) {
+
+        guard let data = try? JSONEncoder().encode(response) else { return }
+        UserDefaults.standard.set(data, forKey: key)
+    }
+
+    // 再取得が必要か。
+    // 「最新の version が現在のアプリバージョンと一致するときのみスキップ」、
+    // それ以外（初回・空・アップデート後など）は取得する。
+    static func needsRefresh() -> Bool {
+
+      // キャッシュが存在しないか、またはキャッシュの中身が0件だった場合はtrue(つまり、更新情報を取得しないといけない)
+        guard let cached = load(),
+              let latest = cached.updates.first else { return true }
+        return currentAppVersion.compare(latest.version, options: .numeric) != .orderedSame
+    }
+}

--- a/Zidosuta/Model/Logic/API/ZidosutaUpdates/UpdatesCache.swift
+++ b/Zidosuta/Model/Logic/API/ZidosutaUpdates/UpdatesCache.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum UpdateInfoCache {
+enum UpdatesCache {
     private static let key = "cachedUpdates"
 
     // 現在のアプリバージョン（Info.plist の CFBundleShortVersionString）。
@@ -36,7 +36,19 @@ enum UpdateInfoCache {
 
       // キャッシュが存在しないか、またはキャッシュの中身が0件だった場合はtrue(つまり、更新情報を取得しないといけない)
         guard let cached = load(),
-              let latest = cached.updates.first else { return true }
+              let latest = cached.updates.first else {
+          print("キャッシュがないか、有効な更新情報がないため更新が必要です")
+          return true
+        }
+
+      let test = currentAppVersion.compare(latest.version, options: .numeric) != .orderedSame
+
+      if test {
+        print("更新する必要があります")
+      } else {
+        print("更新する必要がありません")
+      }
+
         return currentAppVersion.compare(latest.version, options: .numeric) != .orderedSame
     }
 }

--- a/Zidosuta/Model/Logic/API/ZidosutaUpdates/ZidosutaUpdate.swift
+++ b/Zidosuta/Model/Logic/API/ZidosutaUpdates/ZidosutaUpdate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ZidosutaUpdate: Decodable {
+struct ZidosutaUpdate: Codable {
 
   let version: String
   let description: String

--- a/Zidosuta/Model/Logic/API/ZidosutaUpdates/ZidosutaUpdatesResponse.swift
+++ b/Zidosuta/Model/Logic/API/ZidosutaUpdates/ZidosutaUpdatesResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ZidosutaUpdatesResponse: Decodable {
+struct ZidosutaUpdatesResponse: Codable {
 
   let updates: [ZidosutaUpdate]
 }


### PR DESCRIPTION
## issue
close #362 

## やったこと
- キャッシュ周りの処理を担当するモデルのUpdatesCacheを作成
- UpdatesCacheを利用して、キャッシュの有無で更新情報取得処理を行うかどうかをハンドリングできるようにした
