### PR TITLE
更新情報取得に失敗した時にアラートを表示して、前の画面に戻れるようにした

### DIFF
--- a/Zidosuta.xcodeproj/project.pbxproj
+++ b/Zidosuta.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		FAD64E7D2FE100050081D564 /* UpdatesDisplayTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD64E7B2FE100050081D564 /* UpdatesDisplayTableViewCell.swift */; };
 		FAD64E7E2FE100050081D564 /* UpdatesDisplayTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD64E7C2FE100050081D564 /* UpdatesDisplayTableViewCell.xib */; };
 		FAD88E722FE4EFF0006B6667 /* UpdatesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD88E712FE4EFF0006B6667 /* UpdatesCache.swift */; };
+		FAD88E752FE506E4006B6667 /* FetchUpdatesAlertString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD88E742FE506E4006B6667 /* FetchUpdatesAlertString.swift */; };
 		FAD9B7D22FDED82600F49466 /* UpdatesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */; };
 		FAD9B7D32FDED82600F49466 /* UpdatesTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */; };
 		FAD9B7D52FDEE49A00F49466 /* UpdatesDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */; };
@@ -340,6 +341,7 @@
 		FAD64E7B2FE100050081D564 /* UpdatesDisplayTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayTableViewCell.swift; sourceTree = "<group>"; };
 		FAD64E7C2FE100050081D564 /* UpdatesDisplayTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesDisplayTableViewCell.xib; sourceTree = "<group>"; };
 		FAD88E712FE4EFF0006B6667 /* UpdatesCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesCache.swift; sourceTree = "<group>"; };
+		FAD88E742FE506E4006B6667 /* FetchUpdatesAlertString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUpdatesAlertString.swift; sourceTree = "<group>"; };
 		FAD9B7D02FDED82600F49466 /* UpdatesTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesTableViewCell.swift; sourceTree = "<group>"; };
 		FAD9B7D12FDED82600F49466 /* UpdatesTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdatesTableViewCell.xib; sourceTree = "<group>"; };
 		FAD9B7D42FDEE49A00F49466 /* UpdatesDisplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesDisplayViewController.swift; sourceTree = "<group>"; };
@@ -825,6 +827,7 @@
 				FAA9E7322FA4EA2A00CBED1E /* SettingsCellString.swift */,
 				FAA9E7342FA4EB3700CBED1E /* EmailAlertString.swift */,
 				FAA9E7402FA6291E00CBED1E /* DeletionAlertString.swift */,
+				FAD88E742FE506E4006B6667 /* FetchUpdatesAlertString.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -1409,6 +1412,7 @@
 				FA0572F12FDFB4CB00486AD7 /* APIClient.swift in Sources */,
 				FAC9EF2F2D0C11E000DE1E64 /* TopDateManager.swift in Sources */,
 				FA42FA3A2A70B2DC00C60F9E /* DateRangeCalculator.swift in Sources */,
+				FAD88E752FE506E4006B6667 /* FetchUpdatesAlertString.swift in Sources */,
 				FA11122C2A5923F6007353EA /* IndexSetter.swift in Sources */,
 				FAFF6F592A21ACE40092A1A3 /* WeightTableViewCell.swift in Sources */,
 				FA2211172CFF5E1B005C622D /* NotificationTimeDisplayTableViewCell.swift in Sources */,

--- a/Zidosuta/Controller/Settings/Constant/FetchUpdatesAlertString.swift
+++ b/Zidosuta/Controller/Settings/Constant/FetchUpdatesAlertString.swift
@@ -1,0 +1,19 @@
+//
+//  FetchUpdatesAlertString.swift
+//  Zidosuta
+//
+//  Created by 川島真之 on 2026/06/19.
+//
+
+import Foundation
+
+enum FetchUpdatesAlertString {
+
+  static let okActionTitle = "OK"
+
+  enum FetchFailure {
+
+    static let title = "更新情報が取得できませんでした"
+    static let message = "更新情報はApp Storeのアプリのページからもご確認いただけます。"
+  }
+}

--- a/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
+++ b/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
@@ -61,8 +61,6 @@ class UpdatesDisplayViewController: UIViewController {
 
     if UpdatesCache.needsRefresh() {
 
-      // FIXME: - 更新情報の取得処理がDRYに違反しているため、エラーハンドリング実装後に共通化する
-
       // キャッシュが存在しない等で更新情報の取得が必要な場合
       indicator.startAnimating()
 
@@ -77,6 +75,7 @@ class UpdatesDisplayViewController: UIViewController {
         } catch {
           // エラーハンドリング
           print("エラー発生")
+          showUpdatesFetchFailureAlert()
           indicator.stopAnimating()
         }
       }
@@ -101,6 +100,7 @@ class UpdatesDisplayViewController: UIViewController {
           } catch {
             // エラーハンドリング
             print("エラー発生")
+            showUpdatesFetchFailureAlert()
             indicator.stopAnimating()
           }
         }
@@ -173,6 +173,16 @@ extension UpdatesDisplayViewController {
     return try await  client.request(request)
   }
 
-  private showErrorAlert
+  private func showUpdatesFetchFailureAlert() {
+
+    let alert = UIAlertController(title: FetchUpdatesAlertString.FetchFailure.title, message: FetchUpdatesAlertString.FetchFailure.message, preferredStyle: .alert)
+
+    let okAction = UIAlertAction(title: FetchUpdatesAlertString.okActionTitle, style: .default) { action in
+      self.navigationController?.popViewController(animated: true)
+    }
+
+    alert.addAction(okAction)
+    present(alert, animated: true)
+  }
 
 }

--- a/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
+++ b/Zidosuta/Controller/Settings/UpdatesDisplayViewController.swift
@@ -68,7 +68,7 @@ class UpdatesDisplayViewController: UIViewController {
 
       Task {
         do {
-          let result = try await getUpdates()
+          let result = try await fetchUpdates()
           UpdatesCache.save(result)
           configureDataSource()
           applyData(data: result.updates)
@@ -92,7 +92,7 @@ class UpdatesDisplayViewController: UIViewController {
 
         Task {
           do {
-            let result = try await getUpdates()
+            let result = try await fetchUpdates()
             UpdatesCache.save(result)
             configureDataSource()
             applyData(data: result.updates)
@@ -165,12 +165,14 @@ extension UpdatesDisplayViewController {
     dataSource.apply(snapshot, animatingDifferences: false)
   }
 
-  private func getUpdates() async throws -> ZidosutaUpdatesResponse {
+  private func fetchUpdates() async throws -> ZidosutaUpdatesResponse {
 
     let client = APIClient()
     let request = ZidosutaUpdatesRequest()
 
     return try await  client.request(request)
   }
+
+  private showErrorAlert
 
 }


### PR DESCRIPTION
## issue
close #364 
## やったこと
- 更新情報取得失敗アラートの実装
- アラートに表示する文字列を管理するEnumを作成

## やっていないこと
その他のエラーハンドリグ処理。今後検討する
